### PR TITLE
fix/ ai 팀 리뷰어 설정 오류 수정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @100-hours-a-week/17
+* @100-hours-a-week/NewSum_AI


### PR DESCRIPTION
feature -> dev로 PR시 ai 팀 리뷰어가 전체 팀으로 할당 되는 것을 AI팀으로만 할당되게 수정했습니다.