### PR TITLE
Feat/langgraph refactor - state & hitl test

### DIFF
--- a/app/api/v1/background_tasks.py
+++ b/app/api/v1/background_tasks.py
@@ -1,4 +1,137 @@
 # ai/app/api/v1/background_tasks.py (Trace ID 일관성 및 최종 상태 처리 수정)
+
+# version 2. (2025-05-22)
+import uuid
+import traceback
+from typing import Dict, Any, Optional
+from fastapi import BackgroundTasks, HTTPException
+from datetime import datetime, timezone
+
+from app.utils.logger import get_logger, summarize_for_logging
+from app.dependencies import CompiledWorkflowDep, DatabaseClientDep
+
+logger = get_logger(__name__)
+
+
+# Helper shortcuts to safely pull nested keys
+def _g(d: Dict[str, Any], *path, default=None):
+    cur = d
+    for p in path:
+        if cur is None:
+            return default
+        cur = cur.get(p)
+    return cur if cur is not None else default
+
+
+async def trigger_workflow_task(
+    query: str,
+    config: Dict[str, Any],
+    background_tasks: BackgroundTasks,
+    compiled_app: CompiledWorkflowDep,
+    db_client: DatabaseClientDep,
+) -> str:
+    master_comic_id = str(uuid.uuid4())
+    master_trace_id = master_comic_id
+    langgraph_thread_id = master_comic_id
+
+    extra_log = {"trace_id": master_trace_id, "comic_id": master_comic_id}
+    logger.info("BG workflow trigger", extra=extra_log)
+
+    # --- DB PENDING 상태 기록 ---
+    initial_db_state = {
+        "comic_id": master_comic_id,
+        "status": "PENDING",
+        "timestamp_accepted": datetime.now(timezone.utc).isoformat(),
+        "query": query,
+    }
+    await db_client.set(master_comic_id, initial_db_state)
+
+    # 내부 실행 함수 -------------------------------------------------
+    async def workflow_runner(job_id: str, raw_query: str, cfg: Dict[str, Any], trace_id: str):
+        start_ts = datetime.now(timezone.utc)
+        runner_log = {"trace_id": trace_id, "comic_id": job_id}
+
+        try:
+            await db_client.set(job_id, {**initial_db_state, "status": "STARTED", "timestamp_start": start_ts.isoformat()})
+
+            init_input = {
+                "query": {"original_query": raw_query},  # section 경로에 맞춰 배치
+                "config": {"config": cfg},
+                "meta": {"comic_id": job_id, "trace_id": trace_id},
+            }
+
+            final_output: Optional[Dict[str, Any]] = await compiled_app.ainvoke(
+                init_input, config={"configurable": {"thread_id": langgraph_thread_id}}
+            )
+
+            end_ts = datetime.now(timezone.utc)
+            duration = (end_ts - start_ts).total_seconds()
+
+            # ----- 결과 요약 -----
+            final_status = "FAILED"
+            final_msg = "Unexpected result"
+            error_details = None
+            result_summary = None
+
+            if isinstance(final_output, dict):
+                err_msg = _g(final_output, "meta", "error_message")
+                is_ok = err_msg is None
+                final_status = "DONE" if is_ok else "FAILED"
+                final_msg = "성공" if is_ok else err_msg
+                error_details = None if is_ok else err_msg
+
+                # report, idea, scenario, image 등 Section별로 dict를 저장할 때, raw_search_results 등 dict 리스트에 rank 필드가 누락되지 않도록 보완
+                report_content = _g(final_output, "report", "report_content", default="")
+                saved_report_path = _g(final_output, "report", "saved_report_path")
+                comic_ideas = _g(final_output, "idea", "comic_ideas", default=[])
+                comic_scenarios = _g(final_output, "scenario", "comic_scenarios", default=[])
+                generated_comic_images = _g(final_output, "image", "generated_comic_images", default=[])
+                raw_search_results = _g(final_output, "search", "raw_search_results", default=[])
+                if isinstance(raw_search_results, list):
+                    for idx, item in enumerate(raw_search_results):
+                        if isinstance(item, dict) and 'rank' not in item:
+                            item['rank'] = idx + 1
+
+                result_summary = {
+                    "trace_id": _g(final_output, "meta", "trace_id"),
+                    "comic_id": _g(final_output, "meta", "comic_id"),
+                    "final_stage": _g(final_output, "meta", "current_stage"),
+                    # report
+                    "report_len": len(report_content),
+                    "saved_report_path": saved_report_path,
+                    # idea
+                    "ideas_cnt": len(comic_ideas),
+                    # scenario
+                    "scenarios_cnt": len(comic_scenarios),
+                    # images
+                    "images_cnt": len(generated_comic_images),
+                }
+            else:
+                error_details = f"Output type: {type(final_output)}"
+
+            await db_client.set(job_id, {
+                **initial_db_state,
+                "status": final_status,
+                "message": final_msg,
+                "result": result_summary,
+                "error_details": error_details,
+                "timestamp_start": start_ts.isoformat(),
+                "timestamp_end": end_ts.isoformat(),
+                "duration_seconds": round(duration, 2),
+            })
+            logger.info(f"Workflow {final_status}", extra=runner_log)
+
+        except Exception as e:
+            logger.exception("Workflow fatal", extra=runner_log)
+            await db_client.set(job_id, {**initial_db_state, "status": "FAILED", "message": str(e)})
+
+    # FastAPI Background task 등록
+    background_tasks.add_task(workflow_runner, master_comic_id, query, config, master_trace_id)
+    return master_comic_id
+
+
+# version 1. (2025-05-21 back-up)
+'''
 import uuid
 import traceback
 from typing import Dict, Any, Optional
@@ -173,3 +306,4 @@ async def trigger_workflow_task(
     logger.info("백그라운드 작업 스케줄 완료.", extra=extra_log_data)
 
     return master_comic_id
+'''

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from typing import AsyncGenerator
 from pathlib import Path
 import aiohttp # 외부 API 호출용 세션 생성 위해 추가
+from dotenv import load_dotenv
 
 # --- 로깅 및 설정 임포트 ---
 from app.utils.logger import setup_logging, get_logger
@@ -186,6 +187,7 @@ async def shutdown_event(graceful: bool = True):
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """FastAPI lifespan 컨텍스트 관리자"""
+    load_dotenv()
     await startup_event()
     try:
         yield

--- a/app/nodes/n01_initialize_node.py
+++ b/app/nodes/n01_initialize_node.py
@@ -1,129 +1,132 @@
 # ai/app/nodes/n01_initialize_node.py
+"""
+N01InitializeNode for *section-based* WorkflowState.
+- Populates `meta`, `query`, `search`, `report` … subsections instead of flat keys.
+- Leaves every legacy field value intact by storing them **inside** the proper subsection.
+- Returns a partial-dict that LangGraph merges into the main state.
+"""
+
+from __future__ import annotations
+
 import uuid
 import traceback
 from datetime import datetime, timezone
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
-from app.workflows.state import WorkflowState
+from app.workflows.state_v2 import WorkflowState  # ✨ sectioned model
 from app.utils.logger import get_logger, summarize_for_logging
 
 logger = get_logger(__name__)
 
-# N01 설정값 예시 (실제로는 외부 설정 파일 등에서 관리 가능)
 MIN_QUERY_LENGTH = 3
 MAX_QUERY_LENGTH = 512
 
 
 class N01InitializeNode:
-    """(업그레이드됨) 워크플로우 시작 시 상태를 초기화하고 입력 유효성을 검사하는 노드."""
+    """Initialises the section‑based WorkflowState and validates the incoming query."""
 
-    async def run(self, state: WorkflowState) -> Dict[str, Any]: # 입력으로 WorkflowState 객체 전체를 받음
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
         node_name = self.__class__.__name__
 
-        # API 요청에서 전달된 original_query와 config를 사용
-        original_query = state.original_query or ""
-        initial_config = state.config or {}
+        # ------------------------------------------------------------------
+        # 0. Gather incoming values (may be pre‑set by background_tasks)
+        # ------------------------------------------------------------------
+        original_query: str = state.query.original_query or ""
+        initial_config: Dict[str, Any] = state.config.config or {}
 
-
-        # --- ID 일관성 확보 ---
-        # background_tasks에서 comic_id와 trace_id를 전달했다면 해당 값을 사용
-        # state 객체를 통해 이 값들이 이미 설정되어 있을 것임.
-        # LangGraph는 노드 실행 전 상태 객체(state)를 해당 노드의 입력으로 전달함.
-        # 따라서, background_tasks.py에서 initial_workflow_input에 comic_id와 trace_id를 넣었다면,
-        # N01InitializeNode의 state 인자를 통해 이 값들에 접근 가능해야 함.
-
-        # 만약 state.comic_id나 state.trace_id가 None이나 빈 문자열로 들어온다면,
-        # 이는 background_tasks.py에서 initial_workflow_input에 해당 키를 포함시키지 않았거나,
-        # LangGraph의 상태 전달 방식에 대한 이해가 더 필요함을 의미.
-        # 여기서는 state 객체에 이미 올바른 ID가 설정되어 있다고 가정하고 진행.
-        # 또는, 명시적으로 initial_input에서 직접 ID를 가져와서 사용하는 방식도 고려 가능.
-
-        # WorkflowState 모델에 따라 state.comic_id와 state.trace_id가 존재.
-        # 이 값들은 LangGraph가 이전 단계(여기서는 background_task의 ainvoke 호출 시 입력)로부터 전달.
-        comic_id_to_use = state.comic_id
-        trace_id_to_use = state.trace_id
-        # 만약 전달된 ID가 없다면 (예: 워크플로우가 다른 방식으로 시작된 경우) 새로 생성 (Fallback)
-        if not comic_id_to_use:
-            comic_id_to_use = str(uuid.uuid4())
-            logger.warning(f"[{node_name}] comic_id not provided. Generated: {comic_id_to_use}")
-        if not trace_id_to_use:
-            # trace_id는 comic_id와 동일하게 사용하거나, 별도로 관리할 수 있음
-            # 여기서는 comic_id와 동일하게 설정
-            trace_id_to_use = comic_id_to_use
-            if comic_id_to_use != state.comic_id:  # comic_id는 있었는데 trace_id만 없었던 경우
-                logger.warning(f"[{node_name}] trace_id not provided. Using comic_id as trace_id: {trace_id_to_use}")
+        # IDs might already be present in meta; if not, generate.
+        comic_id: Optional[str] = state.meta.comic_id or str(uuid.uuid4())
+        trace_id: Optional[str] = state.meta.trace_id or comic_id
 
         timestamp = datetime.now(timezone.utc).isoformat()
-        writer_id = initial_config.get('writer_id', 'default_writer')
+        writer_id = initial_config.get("writer_id", "default_writer")
 
-        extra_log_data = {
-            'trace_id': trace_id_to_use,  # 일관된 ID 사용
-            'comic_id': comic_id_to_use,  # 일관된 ID 사용
-            'writer_id': writer_id,
-            'node_name': node_name,
-            'retry_count': 0  # 초기화 시 재시도 횟수는 0
+        extra_log = {
+            "trace_id": trace_id,
+            "comic_id": comic_id,
+            "writer_id": writer_id,
+            "node_name": node_name,
+            "retry_count": 0,
         }
 
         logger.info(
-            f"[{node_name}] Entered. Initial query: '{original_query}' | Config: {summarize_for_logging(initial_config, max_len=200)}",
-            extra=extra_log_data
+            f"[{node_name}] Entered. Query: '{original_query}' | Config: {summarize_for_logging(initial_config, 200)}",
+            extra=extra_log,
         )
 
-        # --- 입력 쿼리 유효성 검사 ---
-        error_messages = []
+        # ------------------------------------------------------------------
+        # 1. Validate input query
+        # ------------------------------------------------------------------
+        errors = []
         if not original_query:
-            error_messages.append("Initial query is empty or missing.")
+            errors.append("Initial query is empty or missing.")
         elif len(original_query) < MIN_QUERY_LENGTH:
-            error_messages.append(
-                f"Initial query is too short (min {MIN_QUERY_LENGTH} chars). Query: '{original_query}'")
+            errors.append(f"Query too short (<{MIN_QUERY_LENGTH}).")
         elif len(original_query) > MAX_QUERY_LENGTH:
-            error_messages.append(
-                f"Initial query is too long (max {MAX_QUERY_LENGTH} chars). Query length: {len(original_query)}")
+            errors.append(f"Query too long (>{MAX_QUERY_LENGTH}).")
 
-        if error_messages:
-            full_error_msg = " ".join(error_messages)
-            logger.error(f"[{node_name}] Input validation failed: {full_error_msg}", extra=extra_log_data)
+        if errors:
+            msg = " ".join(errors)
+            logger.error(f"[{node_name}] Validation failed: {msg}", extra=extra_log)
             return {
-                "trace_id": trace_id_to_use,
-                "comic_id": comic_id_to_use,
-                "timestamp": timestamp,
-                "config": initial_config,  # 원본 config 유지
-                "original_query": original_query,  # 원본 query 유지 (오류났어도)
-                "current_stage": "ERROR",  # 명확한 에러 스테이지
-                "error_message": f"N01 Validation Error: {full_error_msg}",  # 최상위 에러 메시지
-                "error_log": [{"stage": node_name, "error": full_error_msg, "timestamp": timestamp}]
+                "meta": {
+                    "trace_id": trace_id,
+                    "comic_id": comic_id,
+                    "timestamp": timestamp,
+                    "current_stage": "ERROR",
+                    "error_message": f"N01 Validation Error: {msg}",
+                    "error_log": [
+                        {"stage": node_name, "error": msg, "timestamp": timestamp}
+                    ],
+                },
+                "query": {
+                    "original_query": original_query,
+                },
+                "config": {"config": initial_config},
             }
 
-        # 상태 업데이트 준비
-        try:
-            update_dict = {
-                "trace_id": trace_id_to_use,
-                "comic_id": comic_id_to_use,
-                "timestamp": timestamp,  # N01에서 생성하는 타임스탬프
-                "query_context": {},
-                "initial_context_results": [],
-                "search_strategy": None,
-                "raw_search_results": None,
-                "report_content": None,
-                "saved_report_path": None,
+        # ------------------------------------------------------------------
+        # 2. Build update‑dict for successful init
+        # ------------------------------------------------------------------
+        update_dict: Dict[str, Any] = {
+            "meta": {
+                "trace_id": trace_id,
+                "comic_id": comic_id,
+                "timestamp": timestamp,
+                "current_stage": node_name,
                 "retry_count": 0,
                 "error_log": [],
                 "error_message": None,
-                "current_stage": node_name  # 현재 노드 이름 설정
-                # original_query와 config는 변경하지 않으므로 update_dict에 포함 X (state에 이미 존재)
-            }
-            logger.info(f"[{node_name}] Initialization complete. State summary: {summarize_for_logging(update_dict)}", extra=extra_log_data)
-            return update_dict
+            },
+            "query": {
+                "original_query": original_query,
+                "query_context": {},
+                "initial_context_results": [],
+            },
+            "search": {
+                "search_strategy": None,
+                "raw_search_results": None,
+            },
+            "report": {
+                "report_content": None,
+                "saved_report_path": None,
+                "hitl_status": None,
+                "hitl_revision_history": [],
+            },
+            "idea": {"comic_ideas": [], "selected_comic_idea_for_scenario": None},
+            "scenario": {"comic_scenarios": [], "thumbnail_image_prompt": None},
+            "image": {"generated_comic_images": []},
+            "upload": {
+                "uploaded_image_urls": [],
+                "uploaded_report_s3_uri": None,
+                "uploaded_translated_report_s3_uri": None,
+            },
+            # keep full config inside its section
+            "config": {"config": initial_config},
+        }
 
-        except Exception as e:
-            error_msg = f"Error during state initialization: {e}"
-            logger.exception(f"[{node_name}] {error_msg}", extra=extra_log_data)
-            return {
-                "trace_id": trace_id_to_use,
-                "comic_id": comic_id_to_use,
-                "timestamp": timestamp,
-                "current_stage": "ERROR",
-                "error_message": f"N01 Initialization Exception: {error_msg}",
-                "error_log": [{"stage": node_name, "error": error_msg, "detail": traceback.format_exc(),
-                               "timestamp": datetime.now(timezone.utc).isoformat()}]
-            }
+        logger.info(
+            f"[{node_name}] Initialization complete.",
+            extra=extra_log,
+        )
+        return update_dict

--- a/app/nodes/n01_initialize_node.py
+++ b/app/nodes/n01_initialize_node.py
@@ -45,13 +45,13 @@ class N01InitializeNode:
         # 만약 전달된 ID가 없다면 (예: 워크플로우가 다른 방식으로 시작된 경우) 새로 생성 (Fallback)
         if not comic_id_to_use:
             comic_id_to_use = str(uuid.uuid4())
-            logger.warning(f"N01: comic_id was not provided, generating a new one: {comic_id_to_use}")
+            logger.warning(f"[{node_name}] comic_id not provided. Generated: {comic_id_to_use}")
         if not trace_id_to_use:
             # trace_id는 comic_id와 동일하게 사용하거나, 별도로 관리할 수 있음
             # 여기서는 comic_id와 동일하게 설정
             trace_id_to_use = comic_id_to_use
             if comic_id_to_use != state.comic_id:  # comic_id는 있었는데 trace_id만 없었던 경우
-                logger.warning(f"N01: trace_id was not provided, using comic_id as trace_id: {trace_id_to_use}")
+                logger.warning(f"[{node_name}] trace_id not provided. Using comic_id as trace_id: {trace_id_to_use}")
 
         timestamp = datetime.now(timezone.utc).isoformat()
         writer_id = initial_config.get('writer_id', 'default_writer')
@@ -65,8 +65,7 @@ class N01InitializeNode:
         }
 
         logger.info(
-            f"Entering node. Initial Query: '{original_query}', "
-            f"Config Summary: {summarize_for_logging(initial_config, max_len=200)}",
+            f"[{node_name}] Entered. Initial query: '{original_query}' | Config: {summarize_for_logging(initial_config, max_len=200)}",
             extra=extra_log_data
         )
 
@@ -83,7 +82,7 @@ class N01InitializeNode:
 
         if error_messages:
             full_error_msg = " ".join(error_messages)
-            logger.error(f"Input validation failed: {full_error_msg}", extra=extra_log_data)
+            logger.error(f"[{node_name}] Input validation failed: {full_error_msg}", extra=extra_log_data)
             return {
                 "trace_id": trace_id_to_use,
                 "comic_id": comic_id_to_use,
@@ -98,31 +97,30 @@ class N01InitializeNode:
         # 상태 업데이트 준비
         try:
             update_dict = {
-                "trace_id": trace_id_to_use,  # 명시적으로 다시 설정하여 확인
-                "comic_id": comic_id_to_use,  # 명시적으로 다시 설정하여 확인
+                "trace_id": trace_id_to_use,
+                "comic_id": comic_id_to_use,
                 "timestamp": timestamp,  # N01에서 생성하는 타임스탬프
-                "query_context": {},  # 초기화
-                "initial_context_results": [],  # 초기화
-                "search_strategy": None,  # 초기화
-                "raw_search_results": None,  # 초기화 (state.py 정의에 따름)
-                "report_content": None,  # 초기화 (state.py 정의에 따름)
-                "saved_report_path": None,  # 초기화 (state.py 정의에 따름)
-                "retry_count": 0,  # 초기화
-                "error_log": [],  # 초기화
-                "error_message": None,  # 초기화
+                "query_context": {},
+                "initial_context_results": [],
+                "search_strategy": None,
+                "raw_search_results": None,
+                "report_content": None,
+                "saved_report_path": None,
+                "retry_count": 0,
+                "error_log": [],
+                "error_message": None,
                 "current_stage": node_name  # 현재 노드 이름 설정
                 # original_query와 config는 변경하지 않으므로 update_dict에 포함 X (state에 이미 존재)
             }
-            logger.info(f"Exiting node. State Initialized. Summary: {summarize_for_logging(update_dict)}",
-                        extra=extra_log_data)
+            logger.info(f"[{node_name}] Initialization complete. State summary: {summarize_for_logging(update_dict)}", extra=extra_log_data)
             return update_dict
 
         except Exception as e:
             error_msg = f"Error during state initialization: {e}"
-            logger.exception(error_msg, extra=extra_log_data)
+            logger.exception(f"[{node_name}] {error_msg}", extra=extra_log_data)
             return {
-                "trace_id": trace_id_to_use, # 명시적으로 다시 설정하여 확인
-                "comic_id": comic_id_to_use, # 명시적으로 다시 설정하여 확인
+                "trace_id": trace_id_to_use,
+                "comic_id": comic_id_to_use,
                 "timestamp": timestamp,
                 "current_stage": "ERROR",
                 "error_message": f"N01 Initialization Exception: {error_msg}",

--- a/app/nodes/n02_analyze_query_node.py
+++ b/app/nodes/n02_analyze_query_node.py
@@ -1,10 +1,12 @@
 # ai/app/nodes/n02_analyze_query_node.py
+from __future__ import annotations
+
 import json  # JSON 파싱은 이제 사용하지 않지만, 혹시 모를 상황 대비 또는 로깅용으로 남겨둘 수 있음
 import traceback
 from typing import Dict, Any, List, Optional  # Optional 추가
 from datetime import datetime, timezone
 
-from app.workflows.state import WorkflowState
+from app.workflows.state_v2 import WorkflowState
 from app.utils.logger import get_logger, summarize_for_logging
 from app.services.llm_service import LLMService
 from app.tools.search.Google_Search_tool import GoogleSearchTool
@@ -278,67 +280,71 @@ Detected Ambiguities (comma-separated, from original query):"""
 
     async def run(self, state: WorkflowState) -> Dict[str, Any]:
         node_name = self.__class__.__name__
-        trace_id = state.trace_id
-        comic_id = state.comic_id
-        writer_id = state.config.get('writer_id', 'default') if isinstance(state.config, dict) else 'default'
-        original_query = state.original_query
-        error_log = list(state.error_log or [])
-        retry_count = state.retry_count or 0
+        meta, query_sec, config_sec = state.meta, state.query, state.config.config
 
-        extra = {'trace_id': trace_id, 'comic_id': comic_id, 'writer_id': writer_id, 'node_name': node_name,
-                 'retry_count': retry_count}
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+        retry_count = meta.retry_count
+        error_log = list(meta.error_log)
+
+        extra = {
+            "trace_id": trace_id,
+            "comic_id": comic_id,
+            "node_name": node_name,
+            "retry_count": retry_count,
+        }
         logger.info(
-            f"Entering node. Input State Summary: {summarize_for_logging(state.model_dump(exclude_none=True), fields_to_show=['original_query', 'current_stage', 'config'])}",
-            extra=extra)
+            "Entering node (section‑aware). Input summary: "
+            f"{summarize_for_logging(state.model_dump(exclude_none=True), fields_to_show=['query.original_query'])}",
+            extra=extra,
+        )
 
-        query_context = {}
-        initial_context_results = []
+        original_query = query_sec.original_query or ""
+        # original_query가 비어 있으면 config에서 가져오거나 meta에서 가져오기 (초기 진입 시)
+        if not original_query:
+            original_query = config_sec.get("original_query") or getattr(meta, "original_query", "")
+            query_sec.original_query = original_query
+
         try:
-            # --- _analyze_query_sequentially 호출 (새로운 방식) ---
+            # 1. 쿼리 분석 (키워드, 유형, 카테고리, 모호성)
             query_analysis_results = await self._analyze_query_sequentially(original_query, trace_id, extra)
-            # -------------------------------------------------------
-            query_context = query_analysis_results  # 여기에는 extracted_keywords, query_type, query_category, detected_ambiguities, error 포함
+            # 2. 초기 컨텍스트 검색
+            initial_context_results = await self._fetch_initial_context_revised(
+                original_query,
+                query_analysis_results.get("extracted_keywords", [original_query]),
+                trace_id,
+                extra
+            )
 
-            # query_context에 sLLM 처리 중 발생한 오류가 있다면 error_log에 추가
-            if query_context.get("error"):
-                error_log.append({
-                    "stage": f"{node_name}._analyze_query_sequentially",
-                    "error": query_context["error"],
-                    "timestamp": datetime.now(timezone.utc).isoformat()
-                })
-            # 오류 유무와 관계없이 query_context는 상태에 저장 (N03에서 활용 가능하도록)
+            # 3. 결과를 state_v2 구조에 맞게 Section 객체에 직접 할당
+            query_sec.query_context = query_analysis_results
+            query_sec.initial_context_results = initial_context_results
+            meta.current_stage = "n03_understand_and_plan"
+            meta.error_log = error_log
+            meta.error_message = query_analysis_results.get("error")
 
-            extracted_terms = query_context.get("extracted_keywords", [original_query])  # fallback은 유지
-            fetch_log_data = extra.copy()
-            initial_context_results = await self._fetch_initial_context_revised(original_query, extracted_terms,
-                                                                                trace_id, fetch_log_data)
-            if 'search_errors' in fetch_log_data:
-                for err_info in fetch_log_data['search_errors']:
-                    error_log.append({
-                        "stage": f"{node_name}._fetch_context",
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        **err_info
-                    })
-            update_dict = {
-                "query_context": query_context,  # sLLM 분석 결과 (오류 메시지 포함 가능)
-                "initial_context_results": initial_context_results,
-                "current_stage": "n03_understand_and_plan",
-                "error_log": error_log
-            }
             logger.info(
-                f"Exiting node. Output Update Summary: {summarize_for_logging(update_dict, fields_to_show=['current_stage', 'query_context'])}",
-                extra=extra)
-            return update_dict
-        except Exception as e:
-            error_msg = f"Unexpected error in N02 node execution: {e}"
-            logger.exception(error_msg, extra=extra)
-            error_log.append({"stage": node_name, "error": error_msg, "detail": traceback.format_exc(),
-                              "timestamp": datetime.now(timezone.utc).isoformat()})
-            # 심각한 예외 발생 시, query_context는 빈 상태로 다음으로 넘어갈 수 있음
-            # 또는 에러 상태로 즉시 종료하는 것이 나을 수도 있음 (현재는 다음 노드로 넘김)
+                "Exiting node. Output Update Summary: "
+                f"{summarize_for_logging({'meta': meta.model_dump()}, fields_to_show=['meta.current_stage'])}",
+                extra=extra,
+            )
             return {
-                "query_context": {"error": f"N02 Unhandled Exception: {str(e)}"},  # 최소한의 컨텍스트 전달
-                "error_log": error_log,
-                "current_stage": "n03_understand_and_plan",  # 또는 "ERROR"
-                "error_message": f"N02 Exception: {error_msg}"
+                "query": query_sec.model_dump(),
+                "meta": meta.model_dump(),
+            }
+
+        except Exception as e:
+            err_msg = f"N02 unexpected error: {e}"
+            logger.exception(err_msg, extra=extra)
+            error_log.append({
+                "stage": node_name,
+                "error": str(e),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            })
+            return {
+                "meta": {
+                    "current_stage": "ERROR",
+                    "error_log": error_log,
+                    "error_message": err_msg,
+                }
             }

--- a/app/nodes/n05_hitl_review_node.py
+++ b/app/nodes/n05_hitl_review_node.py
@@ -84,21 +84,21 @@ class N05HITLReviewNode:
 
     async def _handle_modification(self, state: WorkflowState) -> WorkflowState:
         """보고서 수정 요청을 처리합니다."""
-        console.print("[bold yellow]수정이 필요한 부분을 설명해주세요:[/bold yellow]")
+        console.print("[bold yellow]수정이 필요한 부분을 설명해주세요(slm에게 prompt로 들어갈 내용입니다):[/bold yellow]")
         modification_request = Prompt.ask("수정 요청")
         
         # LLM을 사용하여 보고서 수정
         modification_prompt = f"""
-        다음 보고서를 수정해주세요:
-        
-        원본 보고서:
-        {state.report_content}
-        
-        수정 요청:
-        {modification_request}
-        
-        수정된 보고서를 HTML 형식으로 반환해주세요.
-        """
+Please revise the following report based on the user's feedback.
+
+Original Report:
+{state.report_content}
+
+User's Modification Request:
+{modification_request}
+
+Return the revised report in **HTML format only**.
+"""
         
         try:
             response = await self.llm_service.generate_text(modification_prompt)

--- a/app/nodes/n05_hitl_review_node.py
+++ b/app/nodes/n05_hitl_review_node.py
@@ -1,0 +1,209 @@
+# ai/app/nodes/n05_hitl_review_node.py
+from typing import Dict, Any, Optional
+from datetime import datetime, timezone
+import asyncio
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt, Confirm
+from bs4 import BeautifulSoup
+import re
+
+from app.workflows.state import WorkflowState
+from app.utils.logger import get_logger
+from app.services.llm_service import LLMService
+
+logger = get_logger(__name__)
+console = Console()
+
+class N05HITLReviewNode:
+    """보고서 생성 후 사용자 검토를 위한 HITL 노드"""
+
+    def __init__(self, llm_service: LLMService):
+        self.name = "n05_hitl_review"
+        self.llm_service = llm_service
+        self.MAX_MODIFICATION_ATTEMPTS = 3  # 최대 수정 시도 횟수
+
+    def _extract_summary(self, html_content: str) -> str:
+        """HTML 보고서에서 요약 정보를 추출합니다."""
+        try:
+            soup = BeautifulSoup(html_content, 'html.parser')
+            
+            # 제목 추출
+            title = soup.find('h1')
+            title_text = title.get_text() if title else "제목 없음"
+            
+            # 첫 번째 단락 추출
+            first_p = soup.find('p')
+            first_p_text = first_p.get_text() if first_p else "내용 없음"
+            
+            # 주요 섹션 제목들 추출
+            sections = soup.find_all(['h2', 'h3'])
+            section_titles = [section.get_text() for section in sections[:3]]  # 최대 3개 섹션
+            
+            # 요약본 생성
+            summary = f"""
+제목: {title_text}
+
+요약: {first_p_text[:200]}...
+
+주요 섹션:
+{chr(10).join(f'- {title}' for title in section_titles)}
+"""
+            return summary
+        except Exception as e:
+            logger.error(f"요약 추출 중 오류 발생: {str(e)}")
+            return "요약을 생성할 수 없습니다."
+
+    async def _display_report(self, report_content: str) -> None:
+        """보고서 내용을 CLI에 표시합니다."""
+        # 요약본 생성
+        summary = self._extract_summary(report_content)
+        
+        console.print("\n[bold blue]=== 보고서 요약 ===[/bold blue]")
+        console.print(Panel(summary, title="보고서 요약", border_style="blue"))
+        
+        # 전체 내용 보기 옵션
+        if Confirm.ask("\n전체 보고서 내용을 보시겠습니까?"):
+            console.print("\n[bold blue]=== 전체 보고서 ===[/bold blue]")
+            console.print(Panel(report_content, title="전체 보고서", border_style="blue"))
+        
+        console.print("\n")
+
+    async def _get_user_feedback(self) -> tuple[str, str]:
+        """사용자로부터 피드백을 받습니다."""
+        console.print("[bold yellow]보고서에 대한 피드백을 입력해주세요:[/bold yellow]")
+        feedback = Prompt.ask("피드백")
+        
+        action = Prompt.ask(
+            "다음 작업을 선택하세요",
+            choices=["approve", "reject", "modify"],
+            default="approve"
+        )
+        
+        return action, feedback
+
+    async def _handle_modification(self, state: WorkflowState) -> WorkflowState:
+        """보고서 수정 요청을 처리합니다."""
+        console.print("[bold yellow]수정이 필요한 부분을 설명해주세요:[/bold yellow]")
+        modification_request = Prompt.ask("수정 요청")
+        
+        # LLM을 사용하여 보고서 수정
+        modification_prompt = f"""
+        다음 보고서를 수정해주세요:
+        
+        원본 보고서:
+        {state.report_content}
+        
+        수정 요청:
+        {modification_request}
+        
+        수정된 보고서를 HTML 형식으로 반환해주세요.
+        """
+        
+        try:
+            response = await self.llm_service.generate_text(modification_prompt)
+            # LLM 응답에서 generated_text 추출
+            if isinstance(response, dict) and 'generated_text' in response:
+                modified_report = response['generated_text']
+            else:
+                modified_report = str(response)
+                
+            state.report_content = modified_report
+            
+            # 수정 이력 기록
+            state.hitl_revision_history.append({
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "action": "modify",
+                "feedback": modification_request,
+                "report_content": modified_report
+            })
+            
+            console.print("[bold green]보고서가 수정되었습니다.[/bold green]")
+            return state
+            
+        except Exception as e:
+            logger.error(f"보고서 수정 중 오류 발생: {str(e)}")
+            state.error_message = f"보고서 수정 실패: {str(e)}"
+            state.hitl_status = "error"
+            state.workflow_status = "error"
+            return state
+
+    async def run(self, state: WorkflowState) -> WorkflowState:
+        """
+        HITL 리뷰 프로세스를 실행합니다.
+        
+        Args:
+            state (WorkflowState): 현재 워크플로우 상태
+
+        Returns:
+            WorkflowState: 업데이트된 워크플로우 상태
+        """
+        logger.info(f"[{self.name}] HITL 리뷰 프로세스 시작")
+
+        # HITL 상태 초기화
+        state.hitl_status = "pending"
+        state.hitl_last_updated = datetime.now(timezone.utc).isoformat()
+
+        # 보고서가 없는 경우 에러 처리
+        if not state.report_content:
+            state.error_message = "HITL 리뷰를 위한 보고서가 없습니다."
+            logger.error(f"[{self.name}] {state.error_message}")
+            return state
+
+        # HITL 리뷰 이력 초기화
+        state.hitl_revision_history = [{
+            "timestamp": state.hitl_last_updated,
+            "action": "initial_review",
+            "report_content": state.report_content
+        }]
+
+        # 보고서 표시
+        await self._display_report(state.report_content)
+
+        modification_count = 0
+        while True:
+            # 사용자 피드백 받기
+            action, feedback = await self._get_user_feedback()
+            
+            # 피드백 저장
+            state.hitl_feedback = feedback
+            state.hitl_status = action
+            state.hitl_last_updated = datetime.now(timezone.utc).isoformat()
+            
+            # 수정 이력 기록
+            state.hitl_revision_history.append({
+                "timestamp": state.hitl_last_updated,
+                "action": action,
+                "feedback": feedback
+            })
+
+            if action == "approve":
+                console.print("[bold green]보고서가 승인되었습니다.[/bold green]")
+                break
+            elif action == "reject":
+                console.print("[bold red]보고서가 거부되었습니다.[/bold red]")
+                state.error_message = f"사용자에 의해 보고서가 거부됨: {feedback}"
+                state.hitl_status = "rejected"
+                state.workflow_status = "intentionally_terminated"  # 의도적 종료 상태 추가
+                break
+            elif action == "modify":
+                if modification_count >= self.MAX_MODIFICATION_ATTEMPTS:
+                    console.print("[bold red]최대 수정 횟수(3회)를 초과했습니다.[/bold red]")
+                    state.error_message = "최대 수정 횟수를 초과했습니다."
+                    state.hitl_status = "max_modifications_reached"
+                    state.workflow_status = "intentionally_terminated"  # 의도적 종료 상태 추가
+                    break
+                
+                state = await self._handle_modification(state)
+                if state.error_message:
+                    break
+                
+                modification_count += 1
+                console.print(f"[bold yellow]남은 수정 횟수: {self.MAX_MODIFICATION_ATTEMPTS - modification_count}회[/bold yellow]")
+                
+                # 수정된 보고서 표시
+                await self._display_report(state.report_content)
+                continue
+
+        logger.info(f"[{self.name}] HITL 리뷰 프로세스 완료")
+        return state 

--- a/app/nodes/n06a_contextual_summary_node.py
+++ b/app/nodes/n06a_contextual_summary_node.py
@@ -1,0 +1,97 @@
+import re
+import traceback
+from typing import Dict, Any
+from datetime import datetime, timezone
+
+from app.utils.logger import get_logger, summarize_for_logging
+from app.workflows.state import WorkflowState
+from app.services.llm_service import LLMService
+
+logger = get_logger(__name__)
+
+
+class N06AContextualSummaryNode:
+    """
+    보고서 내용을 refined_intent와 category 기준으로 요약하여 후속 노드(n07, n08 등)에서 사용할 수 있도록
+    핵심 요약(contextual_summary)을 생성합니다.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _strip_html(self, html: str) -> str:
+        text = re.sub(r'<[^>]+>', ' ', html)
+        return re.sub(r'\s+', ' ', text).strip()
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        node_name = self.__class__.__name__
+        trace_id = state.trace_id
+        comic_id = state.comic_id
+        retry_count = state.retry_count or 0
+
+        extra = {
+            "trace_id": trace_id,
+            "comic_id": comic_id,
+            "node_name": node_name,
+            "retry_count": retry_count
+        }
+
+        logger.info(f"Entering node. Input State Summary: {summarize_for_logging(state, fields_to_show=['report_content', 'query_context'])}", extra=extra)
+
+        error_log = list(state.error_log or [])
+
+        try:
+            if not state.report_content:
+                raise ValueError("report_content is missing")
+
+            # 입력값 추출
+            report_text = self._strip_html(state.report_content)
+            refined_intent = state.query_context.get("refined_intent", state.original_query)
+            category = state.query_context.get("query_category", "Other")
+            audience = state.config.get("target_audience", "general_public")
+
+            # 프롬프트 구성
+            system_msg = "You are a helpful summarization assistant."
+            user_msg = f"""
+Summarize the following report with the following rules:
+- Prioritize information related to: \"{refined_intent}\"
+- Focus on category: {category}, audience: {audience}
+- Output 3~5 core insights in concise bullet points or short paragraphs
+
+Report:
+{report_text[:8000]}
+            """
+
+            result = await self.llm_service.generate_text(
+                messages=[
+                    {"role": "system", "content": system_msg},
+                    {"role": "user", "content": user_msg}
+                ],
+                max_tokens=1000,
+                temperature=0.3
+            )
+
+            summary_text = result.get("generated_text", "").strip()
+            state.contextual_summary = summary_text
+
+            logger.info(f"Generated contextual summary (truncated): {summary_text[:200]}...", extra=extra)
+            return {
+                "contextual_summary": summary_text,
+                "current_stage": "n07_comic_ideation",
+                "error_log": error_log
+            }
+
+        except Exception as e:
+            error_msg = f"Error in N06AContextualSummaryNode: {e}"
+            logger.exception(error_msg, extra=extra)
+            error_log.append({
+                "stage": node_name,
+                "error": str(e),
+                "detail": traceback.format_exc(),
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            })
+            return {
+                "current_stage": "ERROR",
+                "error_message": error_msg,
+                "error_log": error_log
+            }

--- a/app/nodes/n07_comic_ideation_node.py
+++ b/app/nodes/n07_comic_ideation_node.py
@@ -1,293 +1,256 @@
 # ai/app/nodes/n07_comic_ideation_node.py
-import traceback
-from typing import Dict, Any, List, Optional
+import re, traceback
 from datetime import datetime, timezone
-import re
+from typing import Any, Dict, List, Optional
 
-from app.workflows.state import WorkflowState  # (상대 경로로 수정 가능성 있음)
-from app.utils.logger import get_logger, summarize_for_logging  # (상대 경로로 수정 가능성 있음)
-# from app.services.llm_service import Llama3VLLMService # 실제 서비스 직접 임포트
-from app.services.llm_service import LLMService  # 프로토콜로 타입 힌팅
+from app.workflows.state import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.services.llm_service import LLMService
 
 logger = get_logger(__name__)
 
-MAX_REPORT_CONTENT_CHARS_FOR_IDEATION = 4000
-MAX_IDEAS_TO_GENERATE = 3
-MAX_RETRY_ATTEMPTS = 2  # 재시도 최대 횟수
+MAX_REPORT_CONTENT_CHARS_FOR_IDEATION = 4_000
+MAX_IDEAS_TO_GENERATE                = 3
+MAX_RETRY_ATTEMPTS                   = 2
 
 
 class N07ComicIdeationNode:
     """
-    보고서 내용 기반 만화 아이디어 생성 (Llama 3 최적화, 재요청 준비)
+    N06A가 만든 contextual_summary(있을 경우) + 보고서 원문을 이용해
+    refined_intent에 부합하는 핵심 Insight를 뽑고 만화 아이디어(<idea> XML) 생성.
     """
 
-    def __init__(self, llm_service: LLMService):  # LLMService 프로토콜 사용
-        self.llm_service = llm_service  # Llama3VLLMService 인스턴스가 주입될 것임
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
 
-    def _is_valid_idea_xml(self, xml_block_content: str) -> bool:
-        """생성된 아이디어 XML 블록의 기본 유효성 검사"""
-        if not xml_block_content or not isinstance(xml_block_content, str):
+    # ──────────────────── 0. 유틸 ────────────────────
+    def _is_valid_idea_xml(self, xml: str) -> bool:
+        if not isinstance(xml, str):
             return False
-        # 필수 태그 존재 여부 확인 (간단한 예시)
-        required_tags = ["<title>", "</title>", "<logline>", "</logline>", "<genre>", "</genre>",
-                         "<target_emotion>", "</target_emotion>", "<key_elements_from_report>",
-                         "</key_elements_from_report>"]
-        return all(tag in xml_block_content for tag in required_tags)
+        required_tags = [
+            "title", "logline", "genre",
+            "target_emotion", "key_elements_from_report"
+        ]
+        for tag in required_tags:
+            if re.search(fr"<{tag}>.*?</{tag}>", xml, flags=re.I | re.S) is None:
+                return False
+        return True
 
     async def _summarize_report_with_sllm(
-            self, text_content: str, max_summary_length_chars: int, trace_id: str, extra_log_data: dict,
-            attempt: int = 1
+        self, text: str, max_len: int, trace_id: str, extra: dict, attempt: int = 1
     ) -> str:
-        approx_words = max_summary_length_chars // 5
-        system_prompt = "You are a helpful assistant that summarizes texts concisely, focusing on critical findings and key information. Ensure the summary is well-structured and captures the essence of the original text."
-        user_prompt = f"Concisely summarize the most critical findings and key information in the following text. The summary should be approximately {approx_words} words and must not exceed {max_summary_length_chars} characters: \n\nReport Content:\n{text_content}"
-        if attempt > 1:  # 재시도 시 프롬프트에 추가 정보
-            user_prompt = f"[Attempt {attempt}/{MAX_RETRY_ATTEMPTS + 1}] Previous summarization attempt might have been too long or missed key details. Please try again. Ensure the summary is concise, within {max_summary_length_chars} chars, and captures critical information.\n\n" + user_prompt
+        approx_words = max_len // 5
+        system_msg   = "You are a helpful assistant that summarizes texts concisely."
+        user_msg = (
+            f"Summarize the key findings below (~{approx_words} words, ≤{max_len} characters):\n\n{text}"
+        )
+        if attempt > 1:
+            user_msg = f"[Retry {attempt}/{MAX_RETRY_ATTEMPTS+1}] " + user_msg
 
-        messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
-        logger.debug(f"Attempting to summarize report (attempt {attempt}). Target chars: {max_summary_length_chars}",
-                     extra=extra_log_data)
+        res = await self.llm_service.generate_text(
+            messages=[{"role": "system", "content": system_msg},
+                      {"role": "user",   "content": user_msg}],
+            max_tokens=1000,
+            temperature=0.3,
+        )
+        out = res.get("generated_text", "").strip()
+        if out:
+            return out
+        if attempt <= MAX_RETRY_ATTEMPTS:
+            return await self._summarize_report_with_sllm(text, max_len, trace_id, extra, attempt + 1)
+        logger.warning("Summarizer fallback (truncate).", extra=extra)
+        return text[:max_len] + "..."
 
-        result = await self.llm_service.generate_text(messages=messages, max_tokens=1000, temperature=0.3)
+    async def _preprocess_report_content(
+        self, html: str, trace_id: str, extra: dict, contextual: Optional[str] = None
+    ) -> str:
+        if contextual:
+            logger.info("Using contextual_summary from N06A.", extra=extra)
+            return contextual.strip()
 
-        if "error" in result or not result.get("generated_text"):
-            logger.error(
-                f"sLLM report summarization failed (attempt {attempt}): {result.get('error', 'No text generated')}",
-                extra=extra_log_data)
-            if attempt <= MAX_RETRY_ATTEMPTS:
-                return await self._summarize_report_with_sllm(text_content, max_summary_length_chars, trace_id,
-                                                              extra_log_data, attempt + 1)
-            logger.warning(f"Max retries reached for summarization. Falling back to truncation.", extra=extra_log_data)
-            return text_content[:max_summary_length_chars] + "..."
+        # HTML → text
+        txt = re.sub(r"<style[^>]*?>.*?</style>", "", html, flags=re.S | re.I)
+        txt = re.sub(r"<script[^>]*?>.*?</script>", "", txt,  flags=re.S | re.I)
+        txt = re.sub(r"<[^>]+>", " ", txt)
+        txt = re.sub(r"\s+", " ", txt).strip()
 
-        summarized_content = result["generated_text"].strip()
-        # (간단한 유효성 검사: 너무 짧거나 길지 않은지 - 여기서는 길이 제한은 프롬프트에 위임)
-        logger.info(
-            f"Report content summarized (attempt {attempt}). Original: {len(text_content)}, Summarized: {len(summarized_content)}",
-            extra=extra_log_data)
-        return summarized_content
+        if len(txt) > MAX_REPORT_CONTENT_CHARS_FOR_IDEATION:
+            txt = await self._summarize_report_with_sllm(
+                txt, MAX_REPORT_CONTENT_CHARS_FOR_IDEATION, trace_id, extra
+            )
+        return txt
 
-    async def _preprocess_report_content(self, html_content: str, trace_id: str, extra_log_data: dict) -> str:
-        text_content = re.sub(r'<style[^>]*?>.*?</style>', '', html_content, flags=re.DOTALL | re.IGNORECASE)
-        text_content = re.sub(r'<script[^>]*?>.*?</script>', '', text_content, flags=re.DOTALL | re.IGNORECASE)
-        text_content = re.sub(r'<[^>]+>', ' ', text_content)
-        text_content = re.sub(r'\s+', ' ', text_content).strip()
-
-        if len(text_content) > MAX_REPORT_CONTENT_CHARS_FOR_IDEATION:
-            logger.info(
-                f"Report content (len: {len(text_content)}) > {MAX_REPORT_CONTENT_CHARS_FOR_IDEATION}. Starting SLM summarization.",
-                extra=extra_log_data)
-            text_content = await self._summarize_report_with_sllm(text_content, MAX_REPORT_CONTENT_CHARS_FOR_IDEATION,
-                                                                  trace_id, extra_log_data)
-        return text_content
-
+    # ──────────────────── 1. Insight 추출 ────────────────────
     async def _extract_key_insights_sllm(
-            self, processed_report_content: str, trace_id: str, extra_log_data: dict,
-            attempt: int = 1
+        self,
+        summary: str,
+        refined_intent: str,
+        category: str,
+        audience: str,
+        trace_id: str,
+        extra: dict,
+        attempt: int = 1,
     ) -> Optional[str]:
-        system_prompt = "You are an analytical assistant. Your task is to identify the 3 to 5 most critical conclusions or novel findings from the provided 'Report Summary'. List them concisely, as these will be the foundation for generating comic ideas. Each insight should be a distinct point."
-        user_prompt = f"""From the 'Report Summary' provided below, please identify and list 3 to 5 most critical conclusions or novel findings.
-Ensure each identified insight is distinct and directly supported by the report content.
 
-Report Summary:
-{processed_report_content}
+        system_msg = (
+            "You are an analytical assistant. List the 3-5 most critical insights that directly answer the "
+            "refined question within the news context."
+        )
+        user_msg = f"""
+[Refined Question] {refined_intent}
+[News Category] {category}     [Target Audience] {audience}
 
-List the critical conclusions/findings (e.g., as a numbered or bulleted list):"""
+[Report Summary]
+{summary}
+
+• Provide 3-5 bullet (or numbered) insights.
+• Each must clearly relate to the refined question.
+"""
         if attempt > 1:
-            user_prompt = f"[Attempt {attempt}/{MAX_RETRY_ATTEMPTS + 1}] Previous attempt to extract insights was not clear or was incomplete. Please ensure you list 3-5 distinct critical findings.\n\n" + user_prompt
+            user_msg = f"[Retry {attempt}/{MAX_RETRY_ATTEMPTS+1}] " + user_msg
 
-        messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
-        logger.debug(f"Attempting to extract key insights (attempt {attempt})...", extra=extra_log_data)
-        result = await self.llm_service.generate_text(messages=messages, max_tokens=500, temperature=0.2)
+        res  = await self.llm_service.generate_text(
+            messages=[{"role": "system", "content": system_msg},
+                      {"role": "user",   "content": user_msg}],
+            max_tokens=400,
+            temperature=0.25,
+        )
+        insights = res.get("generated_text", "").strip()
+        if (insights.count("\n") < 2 or len(insights) < 40) and attempt <= MAX_RETRY_ATTEMPTS:
+            logger.warning("Insight extraction weak, retry.", extra=extra)
+            return await self._extract_key_insights_sllm(
+                summary, refined_intent, category, audience, trace_id, extra, attempt + 1
+            )
+        return insights or None
 
-        if "error" in result or not result.get("generated_text"):
-            logger.error(f"sLLM key insight extraction failed (attempt {attempt}): {result.get('error', 'No text')}",
-                         extra=extra_log_data)
-            if attempt <= MAX_RETRY_ATTEMPTS:
-                return await self._extract_key_insights_sllm(processed_report_content, trace_id, extra_log_data,
-                                                             attempt + 1)
-            return None  # Max retries reached
-
-        extracted_insights = result["generated_text"].strip()
-        # (간단한 유효성 검사: 내용이 있는지, 너무 짧지 않은지)
-        if not extracted_insights or len(extracted_insights) < 10:
-            logger.warning(
-                f"Extracted insights seem too short or empty (attempt {attempt}): '{extracted_insights}'. Retrying if possible.",
-                extra=extra_log_data)
-            if attempt <= MAX_RETRY_ATTEMPTS:
-                return await self._extract_key_insights_sllm(processed_report_content, trace_id, extra_log_data,
-                                                             attempt + 1)
-            return None
-
-        logger.info(f"Extracted key insights (attempt {attempt}): {extracted_insights[:200]}...", extra=extra_log_data)
-        return extracted_insights
-
+    # ──────────────────── 2. Comic Idea 생성 ────────────────────
     async def _generate_comic_ideas_sllm(
-            self, processed_report_content: str, extracted_insights: Optional[str],
-            original_query: str, refined_intent: str,
-            num_ideas: int, config: dict, trace_id: str, extra_log_data: dict,
-            attempt: int = 1
+        self,
+        summary: str,
+        insights: Optional[str],
+        refined_intent: str,
+        original_query: str,
+        category: str,
+        num_ideas: int,
+        config: dict,
+        trace_id: str,
+        extra: dict,
+        attempt: int = 1,
     ) -> List[Dict[str, Any]]:
-        writer_persona = config.get('writer_id', 'general_storyteller')
-        target_audience = config.get('target_audience', 'general_audience')
 
-        system_prompt = f"""You are a creative comic idea generator with the persona '{writer_persona}', targeting a '{target_audience}' audience.
-Your goal is to generate {num_ideas} unique and engaging comic ideas. Each idea MUST strictly follow this XML-like format:
+        writer_persona = config.get("writer_id", "general_storyteller")
+        audience_lbl   = config.get("target_audience", "general_audience")
+
+        # 완전한 XML 스키마 & 규칙
+        schema_block = f"""
 <idea>
-  <title>Comic Title (concise and catchy)</title>
-  <logline>A one or two-sentence core plot or concept, reflecting main report points/insights. This logline should hint at a deeper connection or implication, sparking curiosity.</logline>
-  <genre>Comic Genre (e.g. Comedy)</genre>
-  <target_emotion>Primary emotion to evoke (e.g., Curiosity, Amusement, Empathy, Awareness, Thrill)</target_emotion>
-  <key_elements_from_report>Specific phrases, data points, or direct quotes from the Report Summary supporting the logline and its key insight (comma-separated).</key_elements_from_report>
+  <title> … </title>
+  <logline> … </logline>
+  <genre> … </genre>
+  <target_emotion> … </target_emotion>
+  <key_elements_from_report> … </key_elements_from_report>
 </idea>
+"""
 
-IMPORTANT INSTRUCTIONS:
-1. Base ideas on 'Report Summary' and especially 'Previously Extracted Key Insights' if provided.
-2. Each <logline> MUST directly reflect one or more key insights.
-3. For "depth": Connect insights to 'what if' scenarios, unexpected consequences, or non-obvious underlying causes.
-4. Do NOT invent ideas unrelated to the report. Adhere strictly to the XML format.
-5. Generate exactly {num_ideas} ideas, each enclosed in <idea>...</idea> tags. No other text outside or between these tags.
-"""
-        user_prompt = f"""Based on the information below, generate {num_ideas} comic ideas.
-Report Summary:
-{processed_report_content}
-"""
-        if extracted_insights:
-            user_prompt += f"""
-Previously Extracted Key Insights (Use these as primary inspiration for loglines):
-<extracted_insights>
-{extracted_insights}
-</extracted_insights>
-"""
-        else:
-            user_prompt += "\nNo specific pre-extracted insights were provided; base ideas on the overall Report Summary.\n"
-        user_prompt += f"""
-Original User Query: "{original_query}"
-Refined Core Question: "{refined_intent}"
-"""
+        system_msg = (
+            f"You are a creative comic-idea generator (persona: '{writer_persona}', audience: '{audience_lbl}').\n"
+            f"News Category Context: '{category}'.\n"
+            "Generate exactly "
+            f"{num_ideas} UNIQUE ideas strictly following the XML schema below (no extra text):\n"
+            f"{schema_block}\n"
+            "Rules:\n"
+            "1. Each <logline> must reflect at least one Key Insight.\n"
+            "2. NO unrelated inventions.\n"
+            "3. Output = concatenated <idea> blocks, nothing else."
+        )
+
+        user_msg = f"Report Summary:\n{summary}\n"
+        if insights:
+            user_msg += f"\nKey Insights:\n{insights}\n"
+        user_msg += (
+            f'\nOriginal Query: "{original_query}"\nRefined Question: "{refined_intent}"\n'
+            "Generate ideas now:"
+        )
         if attempt > 1:
-            user_prompt = f"[Attempt {attempt}/{MAX_RETRY_ATTEMPTS + 1}] Previous attempt to generate ideas did not follow the XML format correctly or was incomplete. Please ensure you follow all instructions and the XML structure precisely for {num_ideas} ideas.\n\n" + user_prompt
-        user_prompt += f"\nGenerate {num_ideas} comic ideas now:"
+            user_msg = f"[Retry {attempt}/{MAX_RETRY_ATTEMPTS+1}] " + user_msg
 
-        messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
-        logger.debug(f"Attempting to generate comic ideas (attempt {attempt})...", extra=extra_log_data)
-        result = await self.llm_service.generate_text(messages=messages, max_tokens=2500,
-                                                                    temperature=0.75)
+        res  = await self.llm_service.generate_text(
+            messages=[{"role": "system", "content": system_msg},
+                      {"role": "user",   "content": user_msg}],
+            max_tokens=2_500,
+            temperature=0.75,
+        )
+        raw  = res.get("generated_text", "").strip()
+        blocks = re.findall(r"<idea\b[^>]*>(.*?)</idea>", raw, flags=re.S | re.I)
 
-        generated_ideas = []
-        if "error" in result or not result.get("generated_text"):
-            logger.error(f"sLLM idea generation failed (attempt {attempt}): {result.get('error', 'No text')}",
-                         extra=extra_log_data)
-            if attempt <= MAX_RETRY_ATTEMPTS:
-                return await self._generate_comic_ideas_sllm(processed_report_content, extracted_insights,
-                                                             original_query, refined_intent, num_ideas, config,
-                                                             trace_id, extra_log_data, attempt + 1)
-            return []
-
-        raw_text_output = result["generated_text"].strip()
-        idea_blocks = re.findall(r"<idea>(.*?)</idea>", raw_text_output, re.DOTALL)
-
-        if len(idea_blocks) < num_ideas:
-            logger.warning(
-                f"Expected {num_ideas} idea blocks, but found {len(idea_blocks)} (attempt {attempt}). Raw: {raw_text_output[:300]}",
-                extra=extra_log_data)
-            if attempt <= MAX_RETRY_ATTEMPTS:  # 조건 추가: 모든 아이디어가 제대로 생성되지 않았으면 재시도
-                return await self._generate_comic_ideas_sllm(processed_report_content, extracted_insights,
-                                                             original_query, refined_intent, num_ideas, config,
-                                                             trace_id, extra_log_data, attempt + 1)
-
-        for idx, block_content in enumerate(idea_blocks):
-            if not self._is_valid_idea_xml(block_content):
-                logger.warning(
-                    f"Invalid XML structure for idea block #{idx + 1} (attempt {attempt}). Content: {block_content[:200]}",
-                    extra=extra_log_data)
-                if attempt <= MAX_RETRY_ATTEMPTS:  # 개별 아이템이 아닌 전체 결과셋에 대한 재시도
-                    logger.info(f"Retrying entire idea generation due to invalid block (attempt {attempt}).",
-                                extra=extra_log_data)
-                    return await self._generate_comic_ideas_sllm(processed_report_content, extracted_insights,
-                                                                 original_query, refined_intent, num_ideas, config,
-                                                                 trace_id, extra_log_data, attempt + 1)
-                continue  # Max retries: skip this invalid block
-
-            idea = {}
-            title_match = re.search(r"<title>(.*?)</title>", block_content, re.DOTALL)
-            logline_match = re.search(r"<logline>(.*?)</logline>", block_content, re.DOTALL)
-            genre_match = re.search(r"<genre>(.*?)</genre>", block_content, re.DOTALL)
-            emotion_match = re.search(r"<target_emotion>(.*?)</target_emotion>", block_content, re.DOTALL)
-            elements_match = re.search(r"<key_elements_from_report>(.*?)</key_elements_from_report>", block_content,
-                                       re.DOTALL)
-
-            if title_match: idea['title'] = title_match.group(1).strip()
-            if logline_match: idea['logline'] = logline_match.group(1).strip()
-            if genre_match: idea['genre'] = genre_match.group(1).strip()
-            if emotion_match: idea['target_emotion'] = emotion_match.group(1).strip()
-            if elements_match:
-                idea['key_elements_from_report'] = [el.strip() for el in elements_match.group(1).split(',') if
-                                                    el.strip()]
-            else:
-                idea['key_elements_from_report'] = []
-
-            if idea.get('title') and idea.get('logline'):
-                generated_ideas.append(idea)
-            else:
-                logger.warning(f"Parsed idea block #{idx + 1} missing title or logline (attempt {attempt}).",
-                               extra=extra_log_data)
-                # 이 경우에도 전체 재시도 고려 가능 (위의 _is_valid_idea_xml 에서 이미 처리될 수 있음)
-
-        logger.info(f"Parsed {len(generated_ideas)} comic ideas from LLM output (attempt {attempt}).",
-                    extra=extra_log_data)
-        return generated_ideas[:num_ideas] if generated_ideas else []
-
-    async def run(self, state: WorkflowState) -> Dict[str, Any]:
-        node_name = self.__class__.__name__
-        trace_id = state.trace_id
-        comic_id = state.comic_id
-        config = state.config or {}
-        error_log = list(state.error_log or [])
-        # 상태에서 재시도 카운트 가져오기 또는 초기화 (LangGraph 레벨에서 관리하는 것이 더 적합)
-        # current_retry_attempt = state.get(f"{node_name}_retry_attempt", 1)
-
-        extra = {'trace_id': trace_id, 'comic_id': comic_id, 'node_name': node_name}
-        logger.info(
-            f"Entering node. Input: {summarize_for_logging(state.model_dump(exclude_none=True), fields_to_show=['original_query'])}",
-            extra=extra)
-
-        if not state.report_content:
-            # ... (기존 오류 처리) ...
-            return {"comic_ideas": [], "current_stage": "n08_scenario_generation", "error_log": error_log}
-
-        comic_ideas_list = []
-        try:
-            processed_content = await self._preprocess_report_content(state.report_content, trace_id, extra)
-            if not processed_content.strip() or len(processed_content) < 50:
-                # ... (기존 오류 처리) ...
-                return {"comic_ideas": [], "current_stage": "n08_scenario_generation", "error_log": error_log}
-
-            extracted_insights = await self._extract_key_insights_sllm(processed_content, trace_id, extra)
-
-            original_query = state.original_query or "N/A"
-            refined_intent = state.query_context.get("refined_intent",
-                                                     original_query) if state.query_context else original_query
-
-            comic_ideas_list = await self._generate_comic_ideas_sllm(
-                processed_content, extracted_insights, original_query, refined_intent,
-                MAX_IDEAS_TO_GENERATE, config, trace_id, extra
+        if len(blocks) < num_ideas and attempt <= MAX_RETRY_ATTEMPTS:
+            logger.warning("XML idea blocks missing, retry.", extra=extra)
+            return await self._generate_comic_ideas_sllm(
+                summary, insights, refined_intent, original_query,
+                category, num_ideas, config, trace_id, extra, attempt + 1
             )
 
-            if not comic_ideas_list:
-                logger.warning("No comic ideas were generated by the LLM after all attempts.", extra=extra)
+        ideas: List[Dict[str, Any]] = []
+        for blk in blocks:
+            if not self._is_valid_idea_xml(blk):
+                continue
 
-            # (이하 기존 로깅 및 반환 로직)
-            # ...
-            update_dict = {
-                "comic_ideas": comic_ideas_list,
-                "current_stage": "n08_scenario_generation",
-                "error_log": error_log
-            }
-            logger.info(f"Exiting node. Generated {len(comic_ideas_list)} comic ideas.", extra=extra)
-            return update_dict
+            def _get(tag: str) -> str:
+                m = re.search(fr"<{tag}>(.*?)</{tag}>", blk, flags=re.S | re.I)
+                return m.group(1).strip() if m else ""
 
-        except Exception as e:
-            # ... (기존 예외 처리) ...
-            return {"comic_ideas": [], "error_log": error_log, "current_stage": "n08_scenario_generation",
-                    "error_message": str(e)}
+            ideas.append(
+                {
+                    "title": _get("title"),
+                    "logline": _get("logline"),
+                    "genre": _get("genre"),
+                    "target_emotion": _get("target_emotion"),
+                    "key_elements_from_report": [
+                        e.strip() for e in _get("key_elements_from_report").split(",") if e.strip()
+                    ],
+                }
+            )
+        return ideas[:num_ideas]
+
+    # ──────────────────── 3. run() ────────────────────
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        node_name = self.__class__.__name__
+        extra = {"trace_id": state.trace_id, "comic_id": state.comic_id, "node_name": node_name}
+        logger.info("Entering N07.", extra=extra)
+
+        error_log = list(state.error_log or [])
+        if not state.report_content:
+            logger.error("report_content missing.", extra=extra)
+            return {"comic_ideas": [], "current_stage": "ERROR", "error_log": error_log}
+
+        refined_intent = state.query_context.get("refined_intent", state.original_query)
+        category       = state.query_context.get("query_category", "Other")
+        audience       = state.config.get("target_audience", "general_public")
+        contextual_sum = getattr(state, "contextual_summary", None)
+
+        # 1) Summary 확보
+        summary_text = await self._preprocess_report_content(
+            state.report_content, state.trace_id, extra, contextual_sum
+        )
+        if len(summary_text) < 50:
+            logger.error("Pre-processed summary too short.", extra=extra)
+            return {"comic_ideas": [], "current_stage": "ERROR", "error_log": error_log}
+
+        # 2) Insight 추출
+        insights = await self._extract_key_insights_sllm(
+            summary_text, refined_intent, category, audience, state.trace_id, extra
+        )
+
+        # 3) Idea 생성
+        ideas = await self._generate_comic_ideas_sllm(
+            summary_text, insights, refined_intent, state.original_query,
+            category, MAX_IDEAS_TO_GENERATE, state.config or {},
+            state.trace_id, extra
+        )
+
+        logger.info(f"Generated {len(ideas)} comic ideas.", extra=extra)
+        return {
+            "comic_ideas": ideas,
+            "current_stage": "n08_scenario_generation",
+            "error_log": error_log,
+        }

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -19,6 +19,7 @@ from app.nodes.n02_analyze_query_node import N02AnalyzeQueryNode
 from app.nodes.n03_understand_and_plan_node import N03UnderstandAndPlanNode
 from app.nodes.n04_execute_search_node import N04ExecuteSearchNode
 from app.nodes.n05_report_generation_node import N05ReportGenerationNode
+from app.nodes.n05_hitl_review_node import N05HITLReviewNode  # HITL 노드 추가
 from app.nodes.n06_save_report_node import N06SaveReportNode
 from app.nodes.n07_comic_ideation_node import N07ComicIdeationNode
 from app.nodes.n08_scenario_generation_node import N08ScenarioGenerationNode
@@ -58,6 +59,7 @@ async def compile_workflow(
     n03_understand_and_plan = N03UnderstandAndPlanNode(llm_service=llm_service)
     n04_execute_search = N04ExecuteSearchNode(search_tool=Google_Search_tool)
     n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
+    n05_hitl_review = N05HITLReviewNode(llm_service=llm_service)  # LLM 서비스 주입
     n06_save_report = N06SaveReportNode()
     n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
     n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
@@ -72,6 +74,7 @@ async def compile_workflow(
     workflow.add_node("n03_understand_and_plan", n03_understand_and_plan.run)
     workflow.add_node("n04_execute_search", n04_execute_search.run)
     workflow.add_node("n05_report_generation", n05_report_generation.run)
+    workflow.add_node("n05_hitl_review", n05_hitl_review.run)  # HITL 노드 추가
     workflow.add_node("n06_save_report", n06_save_report.run)
     workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
     workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
@@ -84,16 +87,32 @@ async def compile_workflow(
     workflow.add_edge("n02_analyze_query", "n03_understand_and_plan")
     workflow.add_edge("n03_understand_and_plan", "n04_execute_search")
     workflow.add_edge("n04_execute_search", "n05_report_generation")
-    workflow.add_edge("n05_report_generation", "n06_save_report")
+    workflow.add_edge("n05_report_generation", "n05_hitl_review")  # HITL 노드로 연결
+    
+    # HITL 노드의 결과에 따른 분기 추가
+    def should_continue(state: WorkflowState) -> bool:
+        """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정"""
+        return state.workflow_status != "intentionally_terminated"
+    
+    # HITL 노드에서 조건부 분기 추가
+    workflow.add_conditional_edges(
+        "n05_hitl_review",
+        should_continue,
+        {
+            True: "n06_save_report",  # 계속 진행
+            False: END  # 의도적 종료
+        }
+    )
+    
+    # 나머지 엣지들
     workflow.add_edge("n06_save_report", "n07_comic_ideation")
     workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
     workflow.add_edge("n08_scenario_generation", "n09_image_generation")
-    # workflow.add_edge("n09_image_generation", END)  # <<< N10 실행 후 종료
     workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")
-    workflow.add_edge("n10_finalize_and_notify", END)  # <<< N10 실행 후 종료
+    workflow.add_edge("n10_finalize_and_notify", END)
 
     # --- 워크플로우 컴파일 ---
     compiled_app = workflow.compile()
 
-    logger.info("Main workflow compiled successfully (Nodes 1-9 sequential, ends after n09).") # 로그 메시지 업데이트
+    logger.info("Main workflow compiled successfully with HITL review node.") # 로그 메시지 업데이트
     return compiled_app

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -5,7 +5,7 @@ import aiohttp
 from langgraph.graph import StateGraph, END
 
 # 워크플로우 상태 정의
-from .state import WorkflowState
+from .state_v2 import WorkflowState
 
 # 유틸리티 및 서비스 임포트
 from app.utils.logger import get_logger
@@ -90,24 +90,24 @@ async def compile_workflow(
     workflow.add_edge("n02_analyze_query", "n03_understand_and_plan")
     workflow.add_edge("n03_understand_and_plan", "n04_execute_search")
     workflow.add_edge("n04_execute_search", "n05_report_generation")
-    workflow.add_edge("n05_report_generation", "n06_save_report")
-    # workflow.add_edge("n05_report_generation", "n05_hitl_review")  # HITL 노드로 연결
-    
-    # # HITL 노드의 결과에 따른 분기 추가
-    # def should_continue(state: WorkflowState) -> bool:
-    #     """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정"""
-    #     return state.workflow_status != "intentionally_terminated"
-    
-    # # HITL 노드에서 조건부 분기 추가
-    # workflow.add_conditional_edges(
-    #     "n05_hitl_review",
-    #     should_continue,
-    #     {
-    #         True: "n06_save_report",  # 계속 진행
-    #         False: END  # 의도적 종료
-    #     }
-    # )
-    
+    workflow.add_edge("n05_report_generation", "n05_hitl_review")
+
+    # HITL 노드의 결과에 따른 분기 추가 (Section 구조에 맞게 state.meta.workflow_status 사용)
+    def should_continue(state: WorkflowState) -> bool:
+        """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정 (Section 구조 사용)"""
+        # state.meta.workflow_status가 'intentionally_terminated'이면 종료, 아니면 계속
+        return getattr(state.meta, "workflow_status", None) != "intentionally_terminated"
+
+    # HITL 노드에서 조건부 분기 추가
+    workflow.add_conditional_edges(
+        "n05_hitl_review",
+        should_continue,
+        {
+            True: "n06_save_report",  # 계속 진행
+            False: END  # 의도적 종료
+        }
+    )
+
     # HITL 이후 노드들
     workflow.add_edge("n06_save_report", "n06a_contextual_summary")
     workflow.add_edge("n06a_contextual_summary", "n07_comic_ideation")

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -87,22 +87,23 @@ async def compile_workflow(
     workflow.add_edge("n02_analyze_query", "n03_understand_and_plan")
     workflow.add_edge("n03_understand_and_plan", "n04_execute_search")
     workflow.add_edge("n04_execute_search", "n05_report_generation")
-    workflow.add_edge("n05_report_generation", "n05_hitl_review")  # HITL 노드로 연결
+    workflow.add_edge("n05_report_generation", "n06_save_report")
+    # workflow.add_edge("n05_report_generation", "n05_hitl_review")  # HITL 노드로 연결
     
-    # HITL 노드의 결과에 따른 분기 추가
-    def should_continue(state: WorkflowState) -> bool:
-        """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정"""
-        return state.workflow_status != "intentionally_terminated"
+    # # HITL 노드의 결과에 따른 분기 추가
+    # def should_continue(state: WorkflowState) -> bool:
+    #     """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정"""
+    #     return state.workflow_status != "intentionally_terminated"
     
-    # HITL 노드에서 조건부 분기 추가
-    workflow.add_conditional_edges(
-        "n05_hitl_review",
-        should_continue,
-        {
-            True: "n06_save_report",  # 계속 진행
-            False: END  # 의도적 종료
-        }
-    )
+    # # HITL 노드에서 조건부 분기 추가
+    # workflow.add_conditional_edges(
+    #     "n05_hitl_review",
+    #     should_continue,
+    #     {
+    #         True: "n06_save_report",  # 계속 진행
+    #         False: END  # 의도적 종료
+    #     }
+    # )
     
     # 나머지 엣지들
     workflow.add_edge("n06_save_report", "n07_comic_ideation")

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -21,6 +21,7 @@ from app.nodes.n04_execute_search_node import N04ExecuteSearchNode
 from app.nodes.n05_report_generation_node import N05ReportGenerationNode
 from app.nodes.n05_hitl_review_node import N05HITLReviewNode  # HITL 노드 추가
 from app.nodes.n06_save_report_node import N06SaveReportNode
+from app.nodes.n06a_contextual_summary_node import N06AContextualSummaryNode
 from app.nodes.n07_comic_ideation_node import N07ComicIdeationNode
 from app.nodes.n08_scenario_generation_node import N08ScenarioGenerationNode
 from app.nodes.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
@@ -61,6 +62,7 @@ async def compile_workflow(
     n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
     n05_hitl_review = N05HITLReviewNode(llm_service=llm_service)  # LLM 서비스 주입
     n06_save_report = N06SaveReportNode()
+    n06a_contextual_summary = N06AContextualSummaryNode(llm_service=llm_service)
     n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
     n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
     n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
@@ -76,6 +78,7 @@ async def compile_workflow(
     workflow.add_node("n05_report_generation", n05_report_generation.run)
     workflow.add_node("n05_hitl_review", n05_hitl_review.run)  # HITL 노드 추가
     workflow.add_node("n06_save_report", n06_save_report.run)
+    workflow.add_node("n06a_contextual_summary", n06a_contextual_summary.run)
     workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
     workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
     workflow.add_node("n09_image_generation", n09_image_generation.run) # <<< N09 노드 추가
@@ -105,8 +108,9 @@ async def compile_workflow(
     #     }
     # )
     
-    # 나머지 엣지들
-    workflow.add_edge("n06_save_report", "n07_comic_ideation")
+    # HITL 이후 노드들
+    workflow.add_edge("n06_save_report", "n06a_contextual_summary")
+    workflow.add_edge("n06a_contextual_summary", "n07_comic_ideation")
     workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
     workflow.add_edge("n08_scenario_generation", "n09_image_generation")
     workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")

--- a/app/workflows/state.py
+++ b/app/workflows/state.py
@@ -32,6 +32,12 @@ class WorkflowState(BaseModel):
 
     # --- Node 5 (Report Generation) ---
     report_content: Optional[str] = Field(None, description="생성된 원본 보고서 내용 (HTML)")
+    report_full: Optional[str] = Field(None, description="생성된 원본 보고서 전체 내용 (HTML)")
+    hitl_status: Optional[str] = Field(None, description="HITL 리뷰 상태")
+    hitl_last_updated: Optional[str] = Field(None, description="HITL 리뷰 마지막 업데이트 시각")
+    workflow_status: Optional[str] = Field(None, description="워크플로우 상태")
+    hitl_feedback: Optional[str] = Field(None, description="HITL 리뷰 사용자 피드백")
+    hitl_revision_history: List[Dict[str, Any]] = Field(default_factory=list, description="HITL 리뷰 수정 이력")
     # Node 5에서 생성된, 보고서 작성에 참조된 외부 URL 목록 (N10의 sourceNews와는 별개로 관리)
     referenced_urls_for_report: Optional[List[Dict[str, str]]] = Field(default_factory=list,
                                                                        description="보고서 생성에 참조된 외부 소스 정보 목록 (예: {'title': '기사 제목', 'url': 'http://...'})")

--- a/app/workflows/state.py
+++ b/app/workflows/state.py
@@ -45,6 +45,9 @@ class WorkflowState(BaseModel):
     saved_report_path: Optional[str] = Field(None, description="로컬 저장된 보고서 경로")
     translated_report_path: Optional[str] = Field(None, description="로컬 저장된 번역본 경로")
 
+    # --- N06A: 보고서 문맥 기반 요약 ---
+    contextual_summary: Optional[str] = Field(None, description="refined intent 기반 요약된 보고서 요지")
+
     # --- N07: 아이디어 생성 ---
     comic_ideas: Optional[List[Dict[str, Any]]] = Field(default_factory=list, description="생성된 만화 아이디어 목록")
 

--- a/app/workflows/state.py
+++ b/app/workflows/state.py
@@ -1,78 +1,71 @@
 # ai/app/workflows/state.py
+
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
 from datetime import datetime, timezone
 
 
 class WorkflowState(BaseModel):
-    """워크플로우 상태 정의"""
+    """뉴스 기반 만화 생성 워크플로우의 전체 상태를 관리하는 모델"""
 
-    # --- 메타데이터 ---
-    trace_id: Optional[str] = Field(None, description="실행 추적 ID")
-    comic_id: Optional[str] = Field(None, description="콘텐츠 고유 ID")
+    # --- 공통 메타데이터 ---
+    trace_id: Optional[str] = Field(None, description="워크플로우 실행 추적 ID")
+    comic_id: Optional[str] = Field(None, description="생성된 콘텐츠 고유 ID")
     timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat(),
-                           description="워크플로우 시작/업데이트 시간 (ISO)")
+                           description="워크플로우 시작 또는 갱신 시각 (ISO 형식)")
     current_stage: Optional[str] = Field(None, description="현재 실행 중인 노드 이름")
     retry_count: int = Field(0, description="현재 노드 재시도 횟수")
     error_log: List[Dict[str, Any]] = Field(default_factory=list, description="오류 발생 기록")
-    config: Dict[str, Any] = Field(default_factory=dict, description="워크플로우 설정")
-    original_query: Optional[str] = Field(None, description="사용자의 원본 입력 쿼리")
-    error_message: Optional[str] = Field(None, description="최상위 워크플로우 오류 메시지")
+    config: Dict[str, Any] = Field(default_factory=dict, description="설정값 (ex: writer_id, 스타일)")
+    original_query: Optional[str] = Field(None, description="사용자 최초 입력 쿼리")
+    error_message: Optional[str] = Field(None, description="워크플로우 최상위 오류 메시지")
 
-    # --- Node 2 (Analyze Query) ---
+    # --- N02: 쿼리 분석 ---
     query_context: Dict[str, Any] = Field(default_factory=dict, description="쿼리 분석 결과")
-    initial_context_results: List[Dict[str, Any]] = Field(default_factory=list, description="초기 컨텍스트 검색 결과")
+    initial_context_results: List[Dict[str, Any]] = Field(default_factory=list, description="초기 문맥 검색 결과")
 
-    # --- Node 3 (Understand & Plan) ---
-    search_strategy: Optional[Dict[str, Any]] = Field(None, description="수립된 최종 검색 전략")
+    # --- N03: 검색 전략 수립 ---
+    search_strategy: Optional[Dict[str, Any]] = Field(None, description="검색 전략")
 
-    # --- Node 4 (Execute Search) ---
-    raw_search_results: Optional[List[Dict[str, Any]]] = Field(None,
-                                                               description="실제 검색 실행 결과 (원시)")  # 여기에는 외부 URL 정보 포함 가능
+    # --- N04: 검색 실행 ---
+    raw_search_results: Optional[List[Dict[str, Any]]] = Field(None, description="실제 검색 결과 (외부 URL 포함 가능)")
 
-    # --- Node 5 (Report Generation) ---
-    report_content: Optional[str] = Field(None, description="생성된 원본 보고서 내용 (HTML)")
-    report_full: Optional[str] = Field(None, description="생성된 원본 보고서 전체 내용 (HTML)")
+    # --- N05: 보고서 생성 및 HITL ---
+    report_content: Optional[str] = Field(None, description="보고서 본문 (HTML)")
+    report_full: Optional[str] = Field(None, description="보고서 전체 (HTML)")
     hitl_status: Optional[str] = Field(None, description="HITL 리뷰 상태")
-    hitl_last_updated: Optional[str] = Field(None, description="HITL 리뷰 마지막 업데이트 시각")
-    workflow_status: Optional[str] = Field(None, description="워크플로우 상태")
-    hitl_feedback: Optional[str] = Field(None, description="HITL 리뷰 사용자 피드백")
-    hitl_revision_history: List[Dict[str, Any]] = Field(default_factory=list, description="HITL 리뷰 수정 이력")
-    # Node 5에서 생성된, 보고서 작성에 참조된 외부 URL 목록 (N10의 sourceNews와는 별개로 관리)
+    hitl_last_updated: Optional[str] = Field(None, description="HITL 마지막 업데이트 시각")
+    workflow_status: Optional[str] = Field(None, description="전체 워크플로우 상태")
+    hitl_feedback: Optional[str] = Field(None, description="HITL 사용자 피드백")
+    hitl_revision_history: List[Dict[str, Any]] = Field(default_factory=list, description="HITL 피드백 수정 이력")
     referenced_urls_for_report: Optional[List[Dict[str, str]]] = Field(default_factory=list,
-                                                                       description="보고서 생성에 참조된 외부 소스 정보 목록 (예: {'title': '기사 제목', 'url': 'http://...'})")
+        description="보고서 작성 시 참조한 외부 기사 목록 (예: {'title': ..., 'url': ...})")
 
-    # --- Node 6 (Save Report) ---
-    saved_report_path: Optional[str] = Field(None, description="로컬에 저장된 원본 보고서 파일 경로")
-    translated_report_path: Optional[str] = Field(None, description="로컬에 저장된 번역본 보고서 파일 경로 (N06 생성)")
+    # --- N06: 보고서 저장 ---
+    saved_report_path: Optional[str] = Field(None, description="로컬 저장된 보고서 경로")
+    translated_report_path: Optional[str] = Field(None, description="로컬 저장된 번역본 경로")
 
-    # --- Node 7 (Ideation) ---
+    # --- N07: 아이디어 생성 ---
     comic_ideas: Optional[List[Dict[str, Any]]] = Field(default_factory=list, description="생성된 만화 아이디어 목록")
 
-    # --- Node 8 (Scenario Generation) ---
-    selected_comic_idea_for_scenario: Optional[Dict[str, Any]] = Field(None, description="시나리오 작성을 위해 선택된 만화 아이디어")
-    comic_scenarios: Optional[List[Dict[str, Any]]] = Field(default_factory=list, description="생성된 만화 시나리오 목록")
-    thumbnail_image_prompt: Optional[str] = Field(None, description="썸네일 이미지 생성을 위한 LLM 생성 프롬프트")
+    # --- N08: 시나리오 생성 ---
+    selected_comic_idea_for_scenario: Optional[Dict[str, Any]] = Field(None, description="선택된 아이디어")
+    comic_scenarios: Optional[List[Dict[str, Any]]] = Field(default_factory=list, description="생성된 시나리오 목록")
+    thumbnail_image_prompt: Optional[str] = Field(None, description="썸네일 이미지용 프롬프트")
 
-    # --- Node 9 (Image Generation) ---
+    # --- N09: 이미지 생성 ---
     generated_comic_images: Optional[List[Dict[str, Any]]] = Field(default_factory=list,
-                                                                   description="생성된 만화 장면 이미지 정보 목록 (로컬 경로 포함)")
+        description="생성된 만화 이미지 정보 (로컬 경로 포함)")
 
-    # --- Node 10 (Finalize & Notify) ---
-    # N10에서 생성/업데이트하는 필드들
+    # --- N10: 업로드 및 알림 ---
     uploaded_image_urls: Optional[List[Dict[str, Optional[str]]]] = Field(default_factory=list,
-                                                                          description="S3에 업로드된 이미지 URL(HTTPS) 목록")
-    uploaded_report_s3_uri: Optional[str] = Field(None, description="S3에 업로드된 원본 보고서 URL (HTTPS)")
-    uploaded_translated_report_s3_uri: Optional[str] = Field(None, description="S3에 업로드된 번역본 보고서 URL (HTTPS)")
+        description="S3에 업로드된 이미지 URL 목록")
+    uploaded_report_s3_uri: Optional[str] = Field(None, description="업로드된 보고서 URL")
+    uploaded_translated_report_s3_uri: Optional[str] = Field(None, description="업로드된 번역본 URL")
+    external_api_response: Optional[Dict[str, Any]] = Field(None, description="외부 API 응답 결과 (예: 슬랙 알림 등)")
 
-    # N10에서 폴백으로 번역을 수행했을 경우, 그 내용을 상태로 남길 필요가 있다면 이 필드 사용.
-    # N06에서 이미 translated_report_path로 경로를 전달하므로, 내용 자체는 필수가 아닐 수 있음.
-    # translated_report_html_content_by_n10: Optional[str] = Field(None, description="N10에서 (폴백) 생성한 번역 보고서 HTML 내용")
-
-    external_api_response: Optional[Dict[str, Any]] = Field(None, description="외부 API 호출 결과")
-
-    # api_payload_source_news_sent: Optional[List[Dict[str, str]]] = Field(default_factory=list, description="외부 API로 실제 전송된 sourceNews 페이로드 (보고서 링크만 포함, 디버깅/로깅용)")
-
-    class Config:
-        arbitrary_types_allowed = True
-        validate_assignment = True
+    # --- 모델 설정 (Pydantic v2 방식) ---
+    model_config = {
+        "arbitrary_types_allowed": True,
+        "validate_assignment": True
+    }

--- a/app/workflows/state_v2.py
+++ b/app/workflows/state_v2.py
@@ -1,0 +1,99 @@
+# ai/app/workflows/state.py
+
+from __future__ import annotations
+
+from typing import List, Dict, Any, Optional, TypedDict
+from datetime import datetime, timezone
+from pydantic import BaseModel, Field
+
+
+#  Raw / large TypedDict types
+class RawArticle(TypedDict):
+    url: str
+    title: str
+    snippet: str
+    rank: int
+
+
+#  Section models (BaseModel)
+class MetaSection(BaseModel):
+    trace_id: Optional[str] = None
+    comic_id: Optional[str] = None
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    current_stage: Optional[str] = None
+    retry_count: int = 0
+    error_log: List[Dict[str, Any]] = Field(default_factory=list)
+    workflow_status: Optional[str] = None
+    error_message: Optional[str] = None
+
+
+class QuerySection(BaseModel):
+    original_query: Optional[str] = None
+    query_context: Dict[str, Any] = Field(default_factory=dict)
+    initial_context_results: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class SearchSection(BaseModel):
+    search_strategy: Optional[Dict[str, Any]] = None
+    raw_search_results: Optional[List[RawArticle]] = None  # TypedDict list – 검증 최소화
+
+
+class ReportSection(BaseModel):
+    report_content: Optional[str] = None
+    report_full: Optional[str] = None
+    referenced_urls_for_report: List[Dict[str, str]] = Field(default_factory=list)
+    contextual_summary: Optional[str] = None
+    # HITL
+    hitl_status: Optional[str] = None
+    hitl_last_updated: Optional[str] = None
+    hitl_feedback: Optional[str] = None
+    hitl_revision_history: List[Dict[str, Any]] = Field(default_factory=list)
+    # 저장
+    saved_report_path: Optional[str] = None
+    translated_report_path: Optional[str] = None
+
+
+class IdeaSection(BaseModel):
+    comic_ideas: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class ScenarioSection(BaseModel):
+    selected_comic_idea_for_scenario: Optional[Dict[str, Any]] = None
+    comic_scenarios: List[Dict[str, Any]] = Field(default_factory=list)
+    thumbnail_image_prompt: Optional[str] = None
+
+
+class ImageSection(BaseModel):
+    generated_comic_images: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class UploadSection(BaseModel):
+    uploaded_image_urls: List[Dict[str, Optional[str]]] = Field(default_factory=list)
+    uploaded_report_s3_uri: Optional[str] = None
+    uploaded_translated_report_s3_uri: Optional[str] = None
+    external_api_response: Optional[Dict[str, Any]] = None
+
+
+class ConfigSection(BaseModel):
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+#  Root WorkflowState
+class WorkflowState(BaseModel):
+    meta: MetaSection = Field(default_factory=MetaSection)
+    query: QuerySection = Field(default_factory=QuerySection)
+    search: SearchSection = Field(default_factory=SearchSection)
+    report: ReportSection = Field(default_factory=ReportSection)
+    idea: IdeaSection = Field(default_factory=IdeaSection)
+    scenario: ScenarioSection = Field(default_factory=ScenarioSection)
+    image: ImageSection = Field(default_factory=ImageSection)
+    upload: UploadSection = Field(default_factory=UploadSection)
+    config: ConfigSection = Field(default_factory=ConfigSection)
+
+    # 자유 사용 임시 영역 – 검증 off
+    scratchpad: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {
+        "validate_assignment": False,
+        "arbitrary_types_allowed": True,
+    }


### PR DESCRIPTION
- state 구조 변경 : flat 구조 -> 2중 구조 (node state 전이 + langsmith 로그 확인 용이)
- hitl test : cli 창에서 nodeinterrupt 테스트 용 코드 (n05h 확인)
- n02, n03 수정 : 검색 내용을 "어떤 청중에게" 할 것인지 category 분류를 통해 보고서 주제 미세 수정
- n06a, n07 수정 : 기존 보고서에서 insight 얻는 내용에 query 관련 내용을 추가하여 insight 품질 소폭 개선