### PR TITLE
Feat/node v2

### DIFF
--- a/app/nodes_v2/n01_initialize_node.py
+++ b/app/nodes_v2/n01_initialize_node.py
@@ -13,7 +13,7 @@ import traceback
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-from app.workflows.state_v2 import WorkflowState  # ✨ sectioned model
+from app.workflows.state_v2 import WorkflowState, DEFAULT_IMAGE_MODE  # ✨ sectioned model
 from app.utils.logger import get_logger, summarize_for_logging
 
 logger = get_logger(__name__)
@@ -33,13 +33,24 @@ class N01InitializeNode:
         # ------------------------------------------------------------------
         original_query: str = state.query.original_query or ""
         initial_config: Dict[str, Any] = state.config.config or {}
+        writer_id = str(initial_config.get("writer_id", "1"))
+        # writer_id에 따라 image_mode 자동 세팅
+        if writer_id == "1":
+            initial_config["image_mode"] = "ghibli-flux"
+        elif writer_id == "2":
+            initial_config["image_mode"] = "anything-xl"
+        else:
+            initial_config["image_mode"] = DEFAULT_IMAGE_MODE
+        # debug
+        print()
+        print(f"writer_id: {writer_id} | image_mode: {initial_config['image_mode']}")
+        print()
 
         # IDs might already be present in meta; if not, generate.
         comic_id: Optional[str] = state.meta.comic_id or str(uuid.uuid4())
         trace_id: Optional[str] = state.meta.trace_id or comic_id
 
         timestamp = datetime.now(timezone.utc).isoformat()
-        writer_id = initial_config.get("writer_id", "default_writer")
 
         extra_log = {
             "trace_id": trace_id,

--- a/app/nodes_v2/n01_initialize_node.py
+++ b/app/nodes_v2/n01_initialize_node.py
@@ -1,0 +1,132 @@
+# ai/app/nodes/n01_initialize_node.py
+"""
+N01InitializeNode for *section-based* WorkflowState.
+- Populates `meta`, `query`, `search`, `report` … subsections instead of flat keys.
+- Leaves every legacy field value intact by storing them **inside** the proper subsection.
+- Returns a partial-dict that LangGraph merges into the main state.
+"""
+
+from __future__ import annotations
+
+import uuid
+import traceback
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from app.workflows.state_v2 import WorkflowState  # ✨ sectioned model
+from app.utils.logger import get_logger, summarize_for_logging
+
+logger = get_logger(__name__)
+
+MIN_QUERY_LENGTH = 3
+MAX_QUERY_LENGTH = 512
+
+
+class N01InitializeNode:
+    """Initialises the section‑based WorkflowState and validates the incoming query."""
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        node_name = self.__class__.__name__
+
+        # ------------------------------------------------------------------
+        # 0. Gather incoming values (may be pre‑set by background_tasks)
+        # ------------------------------------------------------------------
+        original_query: str = state.query.original_query or ""
+        initial_config: Dict[str, Any] = state.config.config or {}
+
+        # IDs might already be present in meta; if not, generate.
+        comic_id: Optional[str] = state.meta.comic_id or str(uuid.uuid4())
+        trace_id: Optional[str] = state.meta.trace_id or comic_id
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        writer_id = initial_config.get("writer_id", "default_writer")
+
+        extra_log = {
+            "trace_id": trace_id,
+            "comic_id": comic_id,
+            "writer_id": writer_id,
+            "node_name": node_name,
+            "retry_count": 0,
+        }
+
+        logger.info(
+            f"[{node_name}] Entered. Query: '{original_query}' | Config: {summarize_for_logging(initial_config, 200)}",
+            extra=extra_log,
+        )
+
+        # ------------------------------------------------------------------
+        # 1. Validate input query
+        # ------------------------------------------------------------------
+        errors = []
+        if not original_query:
+            errors.append("Initial query is empty or missing.")
+        elif len(original_query) < MIN_QUERY_LENGTH:
+            errors.append(f"Query too short (<{MIN_QUERY_LENGTH}).")
+        elif len(original_query) > MAX_QUERY_LENGTH:
+            errors.append(f"Query too long (>{MAX_QUERY_LENGTH}).")
+
+        if errors:
+            msg = " ".join(errors)
+            logger.error(f"[{node_name}] Validation failed: {msg}", extra=extra_log)
+            return {
+                "meta": {
+                    "trace_id": trace_id,
+                    "comic_id": comic_id,
+                    "timestamp": timestamp,
+                    "current_stage": "ERROR",
+                    "error_message": f"N01 Validation Error: {msg}",
+                    "error_log": [
+                        {"stage": node_name, "error": msg, "timestamp": timestamp}
+                    ],
+                },
+                "query": {
+                    "original_query": original_query,
+                },
+                "config": {"config": initial_config},
+            }
+
+        # ------------------------------------------------------------------
+        # 2. Build update‑dict for successful init
+        # ------------------------------------------------------------------
+        update_dict: Dict[str, Any] = {
+            "meta": {
+                "trace_id": trace_id,
+                "comic_id": comic_id,
+                "timestamp": timestamp,
+                "current_stage": node_name,
+                "retry_count": 0,
+                "error_log": [],
+                "error_message": None,
+            },
+            "query": {
+                "original_query": original_query,
+                "query_context": {},
+                "initial_context_results": [],
+            },
+            "search": {
+                "search_strategy": None,
+                "raw_search_results": None,
+            },
+            "report": {
+                "report_content": None,
+                "saved_report_path": None,
+                "hitl_status": None,
+                "hitl_revision_history": [],
+            },
+            "idea": {"comic_ideas": [], "selected_comic_idea_for_scenario": None},
+            "scenario": {"comic_scenarios": [], "thumbnail_image_prompt": None},
+            "image": {"generated_comic_images": []},
+            "upload": {
+                "uploaded_image_urls": [],
+                "uploaded_report_s3_uri": None,
+                "uploaded_translated_report_s3_uri": None,
+            },
+            # keep full config inside its section
+            "config": {"config": initial_config},
+        }
+
+        logger.info(
+            f"[{node_name}] Initialization complete.",
+            extra=extra_log,
+        )
+        return update_dict

--- a/app/nodes_v2/n01_initialize_node.py
+++ b/app/nodes_v2/n01_initialize_node.py
@@ -1,4 +1,4 @@
-# ai/app/nodes/n01_initialize_node.py
+# ai/app/nodes_v2/n01_initialize_node.py
 """
 N01InitializeNode for *section-based* WorkflowState.
 - Populates `meta`, `query`, `search`, `report` … subsections instead of flat keys.

--- a/app/nodes_v2/n02_analyze_query_node.py
+++ b/app/nodes_v2/n02_analyze_query_node.py
@@ -1,0 +1,142 @@
+# ai/app/nodes_v2/n02_analyze_query_node.py
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+
+logger = get_logger(__name__)
+
+class N02AnalyzeQueryNode:
+    """
+    (업그레이드됨) 단일 LLM 호출을 통해 쿼리 분석 결과를 JSON으로 반환받고,
+    think_parser_tool로 파싱하여 state.query.query_context에 저장합니다.
+    또한 기존 얕은 검색(_fetch_initial_context_revised)을 통합하여
+    state.query.initial_context_results에 할당합니다.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _build_analysis_prompt(self, query: str, context: str) -> str:
+        schema_example = {
+            "extracted_keywords": ["<키워드1>", "<키워드2>"],
+            "query_type": "<Information Seeking|Comparison|How-to|Problem Solving|Opinion Seeking|Ambiguous|Other>",
+            "query_category": "<IT|Economy|Politics|Other>",
+            "detected_ambiguities": ["<모호어1>", "<모호어2>"],
+            "error": None
+        }
+        # Leisure, Science 제거 안하면 이렇게
+        #"query_category": "<IT|Economy|Politics|Leisure|Science|Other>",
+        json_example = json.dumps(schema_example, ensure_ascii=False, indent=2)
+        return f"""
+You are an expert query analysis agent.
+Use the context below to analyze the user's original query.
+
+# Context Snippets:
+{context}
+
+Return ONLY valid JSON matching the schema below, NO think tags, NO explanation, NO comments.
+
+# JSON Schema Example:
+{json_example}
+
+Original Query: "{query}"
+"""
+
+    async def _fetch_initial_context_revised(
+        self, original_query: str, extracted_terms: List[str], trace_id: str, extra_log: dict
+    ) -> List[Dict[str, Any]]:
+        # 기존 n02의 얕은 검색 로직 유지
+        search_results: List[Dict[str, Any]] = []
+        search_errors: List[Dict[str, Any]] = []
+        queries = [original_query]
+        if extracted_terms:
+            for term in extracted_terms[:2]:
+                if term and term.lower() != original_query.lower():
+                    queries.append(term)
+        for q in dict.fromkeys(queries):
+            try:
+                logger.debug(f"Searching web via CSE for: '{q}'", extra=extra_log)
+                res = await self.search_tool.search_web_via_cse(keyword=q, max_results=3, trace_id=trace_id)
+                if res:
+                    search_results.extend(res)
+            except Exception as e:
+                search_errors.append({"tool": "GoogleCSE_WebSearch", "query": q, "error": str(e)})
+        if search_errors:
+            extra_log['search_errors'] = search_errors
+        logger.debug(f"Fetched {len(search_results)} initial context items", extra=extra_log)
+        return search_results
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        node = self.__class__.__name__
+        meta, query_sec, config = state.meta, state.query, state.config.config
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+        extra = {"trace_id": trace_id, "comic_id": comic_id, "node": node}
+
+        original_query = query_sec.original_query or config.get("original_query", "")
+        query_sec.original_query = original_query
+        logger.info("Entering N02AnalyzeQueryNode: %s", summarize_for_logging(original_query), extra=extra)
+
+        try:
+            # 1) 얕은 검색으로 컨텍스트 확보
+            context = await self._fetch_initial_context_revised(
+                original_query, [], trace_id, extra
+            )
+            snippets = "\n".join([item.get("snippet", item.get("title", "")) for item in context])
+
+            # 2) 프롬프트 생성 및 LLM 호출
+            prompt = self._build_analysis_prompt(original_query, snippets)
+            llm_resp = await self.llm_service.generate_text(
+                system_prompt_content=prompt,
+                prompt=original_query,
+                temperature=0.3,
+                max_tokens=800,
+            )
+            raw_txt = llm_resp.get("generated_text", "")
+            logger.debug("Raw LLM response: %s", raw_txt, extra=extra)
+
+            # 3) JSON 파싱
+            try:
+                parsed = extract_json(raw_txt)
+                logger.debug("Parsed N02 JSON: %s", json.dumps(parsed, ensure_ascii=False), extra=extra)
+            except Exception as e:
+                logger.error("JSON parsing failed in N03: %s", str(e), extra=extra)
+                raise
+            
+
+            # 4) state 업데이트 (기존 n02와 동일한 구조 유지)
+            query_sec.query_context = parsed
+            # 5) 초기 컨텍스트 재검색 (키워드 기반)
+            extracted = parsed.get("extracted_keywords", [])
+            initial_context = await self._fetch_initial_context_revised(
+                original_query, extracted, trace_id, extra
+            )
+            query_sec.initial_context_results = initial_context
+
+            # 메타 업데이트
+            meta.current_stage = "n03_understand_and_plan"
+            meta.error_message = parsed.get("error")
+            meta.error_log = list(meta.error_log)
+
+            logger.info(
+                "Exiting N02AnalyzeQueryNode: stage=%s", meta.current_stage,
+                extra=extra
+            )
+            return {"query": query_sec.model_dump(), "meta": meta.model_dump()}
+
+        except Exception as e:
+            err = f"N02AnalyzeQueryNode failed: {e}"
+            logger.exception(err, extra=extra)
+            meta.error_log.append({
+                "stage": node,
+                "error": str(e),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            })
+            return {"meta": {"current_stage": "ERROR", "error_log": meta.error_log, "error_message": err}}

--- a/app/nodes_v2/n03_understand_and_plan_node.py
+++ b/app/nodes_v2/n03_understand_and_plan_node.py
@@ -1,0 +1,244 @@
+# ai/app/nodes_v2/n03_understand_and_plan_node.py
+import json
+import traceback
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+
+logger = get_logger(__name__)
+
+class N03UnderstandAndPlanNode:
+    """
+    (업그레이드됨) 단일 LLM 호출을 통해 사용자 질의의 진의를 파악하고,
+    검색 전략 및 모호성 해소를 위한 구조화된 JSON 응답을 파싱하여 상태에 반영합니다.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _build_system_prompt(self, audience: str) -> str:
+        # System-level instructions and JSON schema only
+        schema = {
+            "refined_intent": "<string>",
+            "key_aspects_to_search": ["<string>"],
+            "resolutions_for_ambiguities": {"<term>": "<string>"},
+            "unresolved_ambiguities": ["<string>"],
+            "clarification_error": "<string|null>"
+        }
+        schema_example = json.dumps(schema, ensure_ascii=False, indent=2)
+        return f"""
+You are an expert planning agent for a satirical 4-panel comic based on news.
+Your target audience is {audience}.
+Return ONLY valid JSON matching the schema below, NO think tags, NO explanation, NO comments.
+
+JSON Schema:
+{schema_example}
+"""
+
+    def _build_user_prompt(self, state: WorkflowState) -> str:
+        # User message contains original query and context snippets
+        query_sec = state.query
+        audience = state.config.config.get('target_audience', 'general_public')
+        original = query_sec.original_query or ""
+        snippets = query_sec.initial_context_results or []
+        snippet_text = "\n".join([
+            f"- {r.get('source','?')}: {r.get('snippet','')[:100]}..."
+            for r in snippets
+        ])
+        return f"""
+User Original Query:
+{original}
+
+Target Audience: {audience}
+
+Initial Context Snippets:
+{snippet_text}
+"""
+
+    def _adjust_audience_by_category(self, category: str) -> str:
+        mapping = {
+            "IT": "tech_industry",
+            "Economy": "financial_analysts",
+            "Politics": "policy_makers",
+            # "Leisure": "general_public",
+            # "Science": "academic_researchers",
+            "Other": "general_public"
+        }
+        return mapping.get(category, "general_public")
+
+    def _determine_writer_concept(self, refined_intent: str, query_type: Optional[str], config: dict) -> Dict[
+        str, Any]:  # config 추가
+        writer_id = config.get('writer_id', 'default_writer')  # writer_id 직접 활용 가능
+        target_audience = config.get('target_audience', 'general_public')
+
+        concept = {"style": "neutral", "depth": "medium", "audience": target_audience, "trend_sensitivity": "medium"}
+
+        # writer_id에 따른 기본 컨셉 조정 (예시)
+        if "tech_expert" in writer_id:
+            concept.update({"depth": "high", "style": "analytical"})
+        elif "story_teller" in writer_id:
+            concept.update({"style": "narrative"})
+
+        intent_lower = refined_intent.lower();
+        query_type_str = str(query_type).lower()
+        if "how-to" in query_type_str or "how to" in intent_lower or "방법" in refined_intent: concept.update(
+            {"style": "instructional"})
+        if "comparison" in query_type_str or "vs" in intent_lower or "비교" in refined_intent: concept.update(
+            {"style": "analytical", "depth": "high"})
+        if "최신" in refined_intent or "동향" in refined_intent or "trend" in intent_lower or "latest" in intent_lower: concept["trend_sensitivity"] = "high"
+        if len(refined_intent) > 80 and concept["depth"] != "high": concept[
+            "depth"] = "high"  # tech_expert가 아니어도 high로 설정 가능
+
+        return concept
+    
+    def _select_search_tools(self, concept: dict, key_aspects: list[str]) -> List[str]:
+        # (기존 로직 유지)
+        tools = set(["GoogleCSE_WebSearch"])
+        if concept.get("depth") == "high": tools.add("GoogleCSE_NewsSearch")
+        if concept.get("trend_sensitivity") == "high": tools.add("GoogleCSE_NewsSearch")
+        if any(
+                "opinion" in aspect.lower() or "review" in aspect.lower() or "후기" in aspect or "리뷰" in aspect or "평판" in aspect
+                for aspect in key_aspects):
+            tools.add("GoogleCSE_CommunitySearch")
+        return list(tools)
+
+    def _generate_final_search_queries(self, refined_intent: str, resolved_ambiguities_dict: dict,
+                                       key_aspects: list[str], concept: dict, query_context_full: dict,
+                                       selected_tools: list[str]) -> List[str]:
+        # (이전 응답에서 복사, 로깅 개선 부분 포함)
+        final_queries = []
+        replacements = {}
+        for k_with_quotes, v_resolution in resolved_ambiguities_dict.items():
+            if isinstance(v_resolution, str) and \
+                    "Clarification needed:" not in v_resolution and \
+                    "No specific clue" not in v_resolution and \
+                    "sLLM call failed" not in v_resolution:
+                term_key = k_with_quotes.strip("'")
+                # 만약 resolution이 너무 길면, 검색어 치환에는 부적합할 수 있음 (여기서는 그대로 사용)
+                replacements[term_key] = v_resolution.strip()
+
+        logger.debug(f"Applying ambiguity resolutions for query generation: {replacements}",
+                     extra=query_context_full.get('_extra_log_data', {}))
+
+        processed_aspects = set()
+        for aspect in key_aspects[:5]:
+            query = aspect
+            for ambiguous_term, replacement_phrase in replacements.items():
+                # 원본 모호성 용어가 aspect에 있고, replacement가 너무 길지 않을 때만 치환
+                if ambiguous_term in query and len(replacement_phrase) < (
+                        len(ambiguous_term) + 30):  # 예: 해결책이 원본보다 30자 이상 길면 치환 안함
+                    query = query.replace(ambiguous_term, replacement_phrase)
+
+            query_suffix = ""
+            negative_keywords = query_context_full.get("negative_keywords", [])
+            if negative_keywords:
+                query_suffix += " " + " ".join([f"-{neg_kw.strip()}" for neg_kw in negative_keywords if neg_kw.strip()])
+
+            final_query = (query + query_suffix).strip()
+            if final_query and final_query not in processed_aspects:
+                final_queries.append(final_query)
+                processed_aspects.add(final_query)
+
+        if not final_queries and refined_intent:
+            final_queries.append(refined_intent)
+
+        return final_queries[:5]
+
+    def _define_search_parameters(self, concept: dict) -> dict:
+        # (기존 로직 유지)
+        params = {"max_results_per_query": 5}
+        if concept.get("depth") == "high":
+            params["max_results_per_query"] = 7
+        elif concept.get("depth") == "shallow":
+            params["max_results_per_query"] = 3
+        return params
+    
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        query_sec = state.query
+        search_sec = state.search
+        extra = {"trace_id": meta.trace_id, "node": self.__class__.__name__}
+
+        if not query_sec.original_query or query_sec.initial_context_results is None:
+            msg = "Missing inputs for N03"
+            logger.error(msg, extra=extra)
+            meta.current_stage = "ERROR"
+            meta.error_message = msg
+            return {"meta": meta.model_dump()}
+
+        # 1) 청중 설정: category 기반
+        query_category = query_sec.query_context.get("query_category", "Other")
+        target_audience = self._adjust_audience_by_category(query_category)
+        cfg = dict(state.config.config)
+        cfg["target_audience"] = target_audience
+        state.config.config = cfg
+
+        # 2) Prepare prompts
+        system_prompt = self._build_system_prompt(target_audience)
+        user_prompt = self._build_user_prompt(state)
+
+        # 2) Single LLM call with system and user messages
+        llm_resp = await self.llm_service.generate_text(
+            system_prompt_content=system_prompt,
+            prompt=user_prompt,
+            temperature=0.2,
+            max_tokens=1200
+        )
+        raw_txt = llm_resp.get("generated_text", "")
+        logger.debug("Raw N03 LLM response: %s", raw_txt, extra=extra)
+        logger.debug("Target Audience: %s", target_audience, extra=extra)
+
+        # 3) Parse JSON output
+        try:
+            parsed = extract_json(raw_txt)
+            logger.debug("Parsed N03 JSON: %s", json.dumps(parsed, ensure_ascii=False), extra=extra)
+        except Exception as e:
+            logger.error("JSON parsing failed in N03: %s", str(e), extra=extra)
+            raise
+
+        # 4) Update state.query.query_context with parsed values
+        ctx = query_sec.query_context or {}
+        ctx["refined_intent"] = parsed.get("refined_intent")
+        ctx["key_aspects_to_search"] = parsed.get("key_aspects_to_search", [])
+        ctx["resolutions_for_ambiguities"] = parsed.get("resolutions_for_ambiguities", {})
+        ctx["unresolved_ambiguities"] = parsed.get("unresolved_ambiguities", [])
+        ctx["clarification_error"] = parsed.get("clarification_error")
+        query_sec.query_context = ctx
+
+        # 5) 기존 로직: 검색 전략 생성
+        writer_concept = self._determine_writer_concept(
+            ctx.get("refined_intent", query_sec.original_query),
+            ctx.get("query_type"), state.config.config
+        )
+        selected_tools = self._select_search_tools(
+            writer_concept, ctx.get("key_aspects_to_search", [])
+        )
+        final_queries = self._generate_final_search_queries(
+            ctx.get("refined_intent", query_sec.original_query),
+            ctx.get("resolutions_for_ambiguities", {}),
+            ctx.get("key_aspects_to_search", [query_sec.original_query]),
+            writer_concept,
+            ctx,
+            selected_tools
+        )
+        search_sec.search_strategy = {
+            "writer_concept": writer_concept,
+            "selected_tools": selected_tools,
+            "queries": final_queries,
+            "parameters": self._define_search_parameters(writer_concept)
+        }
+
+        meta.current_stage = "n04_execute_search"
+        logger.info(f"N03 completed: queries={final_queries}", extra=extra)
+        return {
+            "query": query_sec.model_dump(),
+            "search": search_sec.model_dump(),
+            "meta": meta.model_dump()
+        }
+
+    # _determine_writer_concept, _select_search_tools,
+    # _generate_final_search_queries, _define_search_parameters 등 기존 로직 유지

--- a/app/nodes_v2/n04_execute_search_node.py
+++ b/app/nodes_v2/n04_execute_search_node.py
@@ -1,0 +1,337 @@
+# ai/app/nodes/n04_execute_search_node.py
+import asyncio
+import traceback
+from typing import Dict, Any, List, Optional
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.tools.search.Google_Search_tool import GoogleSearchTool
+
+logger = get_logger(__name__)
+
+
+class N04ExecuteSearchNode:
+    """
+    N03에서 수립된 검색 전략에 따라 실제 검색을 수행하고 결과를 수집하는 노드.
+    Google 일반 검색과 YouTube 비디오/자막 검색을 병렬적으로 수행하여 데이터 보강.
+    """
+
+    def __init__(self, search_tool: GoogleSearchTool):
+        self.search_tool = search_tool
+        self.default_site_preferences = {
+            "tech_expert_3": {
+                "code_related": ["stackoverflow.com", "github.com"],
+                "research_paper": ["arxiv.org", "semanticscholar.org"],
+            },
+            "community_search_defaults": ["reddit.com"]
+        }
+        self.query_keyword_to_site_category_map = {
+            "code_related": ["code", "python", "javascript", "error", "github", "stack overflow", "programming", "develop"],
+            "research_paper": ["paper", "research", "study", "arxiv", "publication", "citation", "preprint"],
+            "deep_dive_tech": ["deep dive", "technical analysis", "tutorial", "how it works", "internals"],
+            "community": ["review", "opinion", "forum", "discussion", "vs", "recommendation", "advice"],
+            "news": ["news", "latest update", "announcement"]
+        }
+        # YouTube 검색 도구 식별자 정의 (클래스 또는 모듈 레벨)
+        self.youtube_tool_identifier = "YouTubeSearch"
+
+
+    def _get_relevant_user_sites(self, user_preferences: Dict[str, List[str]], query_text: str) -> List[str]:
+        relevant_sites = []
+        query_lower = query_text.lower()
+        for category, keywords in self.query_keyword_to_site_category_map.items():
+            if any(kw in query_lower for kw in keywords):
+                sites_in_category = user_preferences.get(category)
+                if isinstance(sites_in_category, list):
+                    relevant_sites.extend(sites_in_category)
+        return list(set(relevant_sites))
+
+    def _determine_target_sites(
+            self, writer_concept: dict, config: dict, tool_name: str, query_text: str
+    ) -> Optional[List[str]]:
+        sites = []
+        writer_id = config.get("writer_id", "default_writer")
+
+        user_preferences = config.get("user_site_preferences")
+        if isinstance(user_preferences, dict):
+            logger.debug(f"Using user site preferences: {user_preferences}")
+            user_relevant_sites = self._get_relevant_user_sites(user_preferences, query_text)
+            if user_relevant_sites:
+                logger.info(f"Applying user-defined sites for query '{query_text}': {user_relevant_sites}")
+                return user_relevant_sites
+            else:
+                logger.debug("User site preferences found but no matching category for this query. Falling back.")
+
+        if writer_id in self.default_site_preferences:
+            default_prefs = self.default_site_preferences[writer_id]
+            query_lower = query_text.lower()
+            for category, keywords in self.query_keyword_to_site_category_map.items():
+                if category in default_prefs and any(kw in query_lower for kw in keywords):
+                    sites.extend(default_prefs[category])
+
+        if tool_name == "GoogleCSE_CommunitySearch" and "site:" not in query_text.lower():
+            sites.extend(self.default_site_preferences.get("community_search_defaults", []))
+
+        final_sites = list(set(sites)) if sites else None
+        if final_sites:
+            logger.debug(f"Applying fallback/default sites for query '{query_text}': {final_sites}")
+        return final_sites
+
+    def _prepare_advanced_search_options(
+            self, writer_concept: dict, tool_name: str, query_text: str
+    ) -> Dict[str, Any]:
+        options: Dict[str, Any] = {}
+        depth = writer_concept.get("depth", "medium")
+        trend_sensitivity = writer_concept.get("trend_sensitivity", "medium")
+
+        if tool_name == "GoogleCSE_NewsSearch":
+            if trend_sensitivity == "high": options["dateRestrict"] = "m1"
+            elif trend_sensitivity == "medium": options["dateRestrict"] = "m3"
+        elif trend_sensitivity == "high" and "latest" in query_text.lower():
+            options["dateRestrict"] = "m3"
+
+        if depth == "high" and any(kw in query_text.lower() for kw in self.query_keyword_to_site_category_map.get("research_paper", [])):
+            options["fileType"] = "pdf"
+
+        if tool_name == self.youtube_tool_identifier: # self.youtube_tool_identifier 사용
+            if writer_concept.get("Youtube_order"):
+                 options["order"] = writer_concept["Youtube_order"]
+            if writer_concept.get("youtube_video_duration"):
+                 options["videoDuration"] = writer_concept["youtube_video_duration"]
+
+        if options:
+            logger.debug(f"Prepared advanced search options for {tool_name}: {options}")
+        return options
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        search_sec = state.search
+        config_sec = state.config
+        node_name = self.__class__.__name__
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+        config = config_sec.config
+        writer_id = config.get('writer_id', 'default_writer')
+        extra_log_data = {'trace_id': trace_id, 'comic_id': comic_id, 'writer_id': writer_id, 'node_name': node_name}
+        logger.info(f"Entering node. Executing searches based on strategy.", extra=extra_log_data)
+        raw_search_results_accumulator: List[Dict[str, Any]] = []
+        error_log = list(meta.error_log or [])
+        search_strategy = search_sec.search_strategy
+        if not search_strategy or not isinstance(search_strategy, dict) or not search_strategy.get("queries"):
+            msg = "Search strategy or queries missing in state. Skipping search execution."
+            logger.warning(msg, extra=extra_log_data)
+            error_log.append({"stage": node_name, "error": msg, "timestamp": datetime.now(timezone.utc).isoformat()})
+            meta.current_stage = "n05_report_generation"
+            meta.error_log = error_log
+            search_sec.raw_search_results = []
+            return {
+                "search": search_sec.model_dump(),
+                "meta": meta.model_dump(),
+            }
+        queries_from_n03: List[str] = search_strategy.get("queries", [])
+        selected_tools: List[str] = search_strategy.get("selected_tools", ["GoogleCSE_WebSearch"])
+        writer_concept: Dict[str, Any] = search_strategy.get("writer_concept", {})
+        base_search_params: Dict[str, Any] = search_strategy.get("parameters", {"max_results_per_query": 5})
+        logger.info(f"Search plan: {len(queries_from_n03)} queries using tools: {selected_tools}", extra=extra_log_data)
+        for query_text in queries_from_n03:
+            query_extra_log = {**extra_log_data, "current_query": query_text}
+            if not query_text or not isinstance(query_text, str) or query_text.strip().upper() == "N/A":
+                logger.warning(f"Skipping invalid query: '{query_text}'", extra=query_extra_log)
+                continue
+            search_tasks_for_current_query = []
+            for tool_name_iter in selected_tools:
+                if tool_name_iter == self.youtube_tool_identifier: # self.youtube_tool_identifier 사용
+                    continue
+                tool_extra_log_iter = {**query_extra_log, "search_tool": tool_name_iter}
+                current_tool_params = base_search_params.copy()
+                target_sites_for_tool = self._determine_target_sites(writer_concept, config, tool_name_iter, query_text)
+                advanced_options_for_tool = self._prepare_advanced_search_options(writer_concept, tool_name_iter, query_text)
+                current_tool_params.update(advanced_options_for_tool)
+                max_results_for_tool = current_tool_params.pop("max_results_per_query", 5)
+                api_call_coroutine = None
+                if target_sites_for_tool:
+                    api_call_coroutine = self.search_tool.search_specific_sites_via_cse(
+                        keyword=query_text, sites=target_sites_for_tool, max_results=max_results_for_tool,
+                        trace_id=trace_id, **current_tool_params
+                    )
+                elif tool_name_iter == "GoogleCSE_WebSearch":
+                    api_call_coroutine = self.search_tool.search_web_via_cse(
+                        keyword=query_text, max_results=max_results_for_tool, trace_id=trace_id, **current_tool_params
+                    )
+                elif tool_name_iter == "GoogleCSE_NewsSearch":
+                    api_call_coroutine = self.search_tool.search_news_via_cse(
+                        keyword=query_text, max_results=max_results_for_tool, trace_id=trace_id, **current_tool_params
+                    )
+                elif tool_name_iter == "GoogleCSE_CommunitySearch":
+                     api_call_coroutine = self.search_tool.search_communities_via_cse(
+                        keyword=query_text, max_results=max_results_for_tool, trace_id=trace_id, **current_tool_params
+                    )
+                if api_call_coroutine:
+                    async def search_wrapper(coroutine_to_await, tool_name_val, query_text_val, log_ctx_val): # Renamed log_ctx
+                        task_error_log_wrapper = []
+                        try:
+                            logger.info(f"Executing {tool_name_val} for query '{query_text_val}'", extra=log_ctx_val)
+                            results = await coroutine_to_await
+                            processed_items = []
+                            if results:
+                                for idx, res_item in enumerate(results):
+                                    if isinstance(res_item, dict):
+                                        res_item['query_source'] = query_text_val
+                                        res_item['tool_used'] = tool_name_val
+                                        res_item['retrieved_at'] = datetime.now(timezone.utc).isoformat()
+                                        res_item.setdefault('source_domain', urlparse(res_item.get("url", "")).netloc)
+                                        # rank 필드 추가 (1부터 시작)
+                                        res_item['rank'] = idx + 1
+                                        processed_items.append(res_item)
+                                logger.info(f"Found {len(processed_items)} results using {tool_name_val} for '{query_text_val}'.", extra=log_ctx_val)
+                            else:
+                                logger.info(f"No results found using {tool_name_val} for '{query_text_val}'.", extra=log_ctx_val)
+                            return processed_items # Return results list
+                        except Exception as e:
+                            error_msg = f"Search execution failed for query '{query_text_val}' using {tool_name_val}: {e}"
+                            logger.exception(error_msg, extra=log_ctx_val)
+                            task_error_log_wrapper.append({
+                                "stage": f"{node_name}.{tool_name_val}", "query": query_text_val, "error": str(e),
+                                "detail": traceback.format_exc(), "timestamp": datetime.now(timezone.utc).isoformat()
+                            })
+                            return task_error_log_wrapper # Return error log list
+                    search_tasks_for_current_query.append(search_wrapper(api_call_coroutine, tool_name_iter, query_text, tool_extra_log_iter))
+            if self.youtube_tool_identifier in selected_tools: # self.youtube_tool_identifier 사용
+                async def Youtube_and_transcript_task_runner(current_query_text, yt_trace_id):
+                    yt_task_results = []
+                    yt_task_error_log = []
+                    yt_tool_name = self.youtube_tool_identifier # self.youtube_tool_identifier 사용
+                    yt_log_ctx = {**query_extra_log, "search_tool": yt_tool_name}
+
+                    try:
+                        yt_params = base_search_params.copy()
+                        yt_advanced = self._prepare_advanced_search_options(writer_concept, yt_tool_name, current_query_text)
+                        yt_params.update(yt_advanced)
+                        yt_max_videos = yt_params.pop("max_results_per_query", config.get("youtube_max_videos", 3))
+
+                        logger.info(f"Executing YouTube Video Search for query '{current_query_text}' (max: {yt_max_videos})", extra=yt_log_ctx)
+                        videos = await self.search_tool.search_youtube_videos(
+                            keyword=current_query_text, max_results=yt_max_videos, trace_id=yt_trace_id, **yt_params
+                        )
+
+                        if videos:
+                            logger.info(f"Found {len(videos)} YouTube videos for '{current_query_text}'. Fetching transcripts...", extra=yt_log_ctx)
+                            transcript_fetch_coros = []
+                            for video_info_item in videos:
+                                video_id_val = video_info_item.get("video_id")
+                                if video_id_val:
+                                    transcript_langs = config.get("youtube_transcript_languages", ['en', 'ko'])
+                                    translate_to_lang = config.get("youtube_transcript_translate_to", 'en')
+                                    transcript_fetch_coros.append(
+                                        self.search_tool.get_youtube_transcript(
+                                            video_id_val, languages=transcript_langs,
+                                            translate_to_language=translate_to_lang, trace_id=yt_trace_id
+                                        )
+                                    )
+                                else:
+                                    async def _dummy_none_coro(): return None
+                                    transcript_fetch_coros.append(_dummy_none_coro())
+
+                            transcripts_or_errors = await asyncio.gather(*transcript_fetch_coros, return_exceptions=True)
+
+                            for idx, video_data_item in enumerate(videos):
+                                full_video_item = {**video_data_item}
+                                full_video_item['query_source'] = current_query_text
+                                full_video_item['tool_used'] = yt_tool_name
+                                full_video_item['retrieved_at'] = datetime.now(timezone.utc).isoformat()
+                                full_video_item.setdefault('source', 'YouTube')
+                                full_video_item.setdefault('source_domain', 'youtube.com') # 일관성을 위해 유지 또는 실제 도메인
+
+                                transcript_content = transcripts_or_errors[idx]
+                                if isinstance(transcript_content, dict) and transcript_content.get("text") is not None: # text가 None이 아닌지 명시적 확인
+                                    full_video_item['transcript'] = transcript_content["text"]
+                                    full_video_item['transcript_language'] = transcript_content["language"]
+                                    logger.debug(f"Transcript added for video {video_data_item.get('video_id')}", extra=yt_log_ctx)
+                                elif isinstance(transcript_content, Exception):
+                                    logger.warning(f"Failed to fetch transcript for video {video_data_item.get('video_id')}: {transcript_content}", extra=yt_log_ctx)
+                                    full_video_item['transcript_error'] = str(transcript_content)
+                                elif transcript_content is None:
+                                    logger.debug(f"No transcript found or fetch returned None for video {video_data_item.get('video_id')}", extra=yt_log_ctx)
+                                    full_video_item['transcript'] = "" # 또는 None, 일관성 유지
+                                    full_video_item['transcript_language'] = None
+
+                                yt_task_results.append(full_video_item)
+                        else:
+                             logger.info(f"No YouTube videos found for '{current_query_text}'.", extra=yt_log_ctx)
+
+                    except Exception as e_main_yt:
+                        error_msg_yt_task = f"Youtube & transcript task failed for query '{current_query_text}': {e_main_yt}"
+                        logger.exception(error_msg_yt_task, extra=yt_log_ctx)
+                        yt_task_error_log.append({
+                            "stage": f"{node_name}.{yt_tool_name}_Task", "query": current_query_text, "error": str(e_main_yt),
+                            "detail": traceback.format_exc(), "timestamp": datetime.now(timezone.utc).isoformat()
+                        })
+
+                    if yt_task_error_log:
+                        return yt_task_error_log # Return error log list
+                    return yt_task_results # Return results list
+
+                search_tasks_for_current_query.append(Youtube_and_transcript_task_runner(query_text, trace_id))
+
+            if search_tasks_for_current_query:
+                logger.info(f"Executing {len(search_tasks_for_current_query)} search tasks in parallel for query: '{query_text}'", extra=query_extra_log)
+                results_from_all_tasks = await asyncio.gather(*search_tasks_for_current_query, return_exceptions=True)
+
+                for single_task_outcome in results_from_all_tasks:
+                    if isinstance(single_task_outcome, list):
+                        # 결과 리스트이거나 오류 로그 리스트일 수 있음
+                        if single_task_outcome and isinstance(single_task_outcome[0], dict) and "stage" in single_task_outcome[0] and "error" in single_task_outcome[0]:
+                            error_log.extend(single_task_outcome) # 오류 로그 리스트인 경우
+                        else: # 실제 검색 결과인 경우
+                            raw_search_results_accumulator.extend(item for item in single_task_outcome if isinstance(item, dict))
+                    elif isinstance(single_task_outcome, Exception):
+                        logger.error(f"A top-level task aggregation failed for query '{query_text}': {single_task_outcome}", extra=query_extra_log)
+                        error_log.append({
+                            "stage": f"{node_name}.gather_exception", "query": query_text, "error": str(single_task_outcome),
+                            "detail": traceback.format_exc(), "timestamp": datetime.now(timezone.utc).isoformat()
+                        })
+            else:
+                logger.info(f"No search tasks to execute for query: '{query_text}'", extra=query_extra_log)
+
+        unique_results = []
+        seen_identifiers = set()
+
+        for idx, item in enumerate(raw_search_results_accumulator):
+            identifier = None
+            # self.youtube_tool_identifier를 여기서 사용 (오류 1 수정)
+            if item.get('tool_used') == self.youtube_tool_identifier and item.get('video_id'):
+                identifier = f"youtube_{item['video_id']}"
+            elif item.get('url'):
+                identifier = item['url']
+
+            if identifier and identifier not in seen_identifiers:
+                # rank 필드 보장 (unique_results 내에서 1부터)
+                item['rank'] = len(unique_results) + 1
+                unique_results.append(item)
+                seen_identifiers.add(identifier)
+            elif not identifier:
+                item['rank'] = len(unique_results) + 1
+                unique_results.append(item)
+
+        logger.info(
+            f"Total raw search results collected across all queries: {len(raw_search_results_accumulator)}, Unique results after final processing: {len(unique_results)}",
+            extra=extra_log_data)
+
+        search_sec.raw_search_results = unique_results
+        meta.current_stage = "n05_report_generation"
+        meta.error_log = error_log
+        update_dict_summary_for_log = {
+            'raw_search_results_count': len(unique_results),
+            'current_stage': meta.current_stage,
+            'error_log': error_log
+        }
+        logger.info(
+            f"Exiting node. Search execution complete. Output Update Summary: {summarize_for_logging(update_dict_summary_for_log, fields_to_show=['current_stage', 'raw_search_results_count', 'error_log'])}", # 수정된 요약 사용
+            extra=extra_log_data)
+
+        return {
+            "search": search_sec.model_dump(),
+            "meta": meta.model_dump(),
+        }

--- a/app/nodes_v2/n04_execute_search_node.py
+++ b/app/nodes_v2/n04_execute_search_node.py
@@ -1,4 +1,4 @@
-# ai/app/nodes/n04_execute_search_node.py
+# ai/app/nodes_v2/n04_execute_search_node.py
 import asyncio
 import traceback
 from typing import Dict, Any, List, Optional

--- a/app/nodes_v2/n05_report_generation_node.py
+++ b/app/nodes_v2/n05_report_generation_node.py
@@ -1,0 +1,208 @@
+# ai/app/nodes_v2/n05_report_generation_node.py
+
+from __future__ import annotations
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import jinja2
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+
+logger = get_logger(__name__)
+
+
+class N05ReportGenerationNode:
+    """
+    (업그레이드됨) Qwen3 기반 한 번의 LLM 호출로
+    구조화된 보고서 JSON을 반환받고, Jinja2 템플릿으로 HTML을 렌더링하여
+    state.report.report_content에 저장하는 노드.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+        self.jinja_env = jinja2.Environment(
+            loader=jinja2.FunctionLoader(self._load_template),
+            autoescape=True
+        )
+        self.template_name = "deep_research_report_template.jinja2"
+
+    def _load_template(self, name: str) -> Optional[str]:
+        if name != self.template_name:
+            return None
+        # 복사해 온 기존 Jinja2 템플릿
+        return """<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title | e }}</title>
+    <style>
+        body { font-family: sans-serif; line-height: 1.6; margin: 20px; }
+        h1, h2, h3 { color: #333; }
+        .section { margin-bottom: 25px; padding-bottom: 15px; border-bottom: 1px solid #eee; }
+        .sources li { margin-bottom: 5px; }
+        .summary { font-style: italic; color: #555; margin-bottom:15px; padding:10px; background-color:#f9f9f9; border-left: 3px solid #007bff; }
+    </style>
+</head>
+<body>
+    <h1>{{ title | e }}</h1>
+    <p class="summary"><strong>요청 쿼리:</strong> {{ original_query | e }}<br>
+    <strong>정제된 핵심 질문:</strong> {{ refined_intent | e }}</p>
+
+    <div class="section">
+        <h2>1. 서론 (Introduction)</h2>
+        <p>{{ introduction | replace('\\n', '<br>') | safe }}</p>
+    </div>
+
+    {% for sec in sections %}
+    <div class="section">
+        <h2>{{ loop.index + 1 }}. {{ sec.aspect_title | e }}</h2>
+        <p>{{ sec.content | replace('\\n', '<br>') | safe }}</p>
+    </div>
+    {% endfor %}
+
+    <div class="section">
+        <h2>{{ sections|length + 2 }}. 결론 (Conclusion)</h2>
+        <p>{{ conclusion | replace('\\n', '<br>') | safe }}</p>
+    </div>
+
+    {% if sources %}
+    <div class="section sources">
+        <h2>{{ sections|length + 3 }}. 참고 자료 (Sources)</h2>
+        <ul>
+            {% for src in sources %}
+            <li><a href="{{ src.url }}" target="_blank">{{ src.title | e }}</a>
+                (검색 엔진: {{ src.tool_used | e }})</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+    <hr>
+    <p><small>본 보고서는 AI에 의해 {{ generation_timestamp }}에 생성되었습니다.
+    Writer Persona: {{ writer_id }}</small></p>
+</body>
+</html>
+"""
+
+    def _build_system_prompt(self, original_query: str, refined_intent: str, snippets: List[Dict[str, Any]]) -> str:
+        """
+        Qwen3에게 JSON 스키마에 맞춰 보고서 내용을 생성하도록 지시하는 System Prompt.
+        """
+        schema_example = {
+            "title": "<string>",
+            "introduction": "<string>",
+            "sections": [
+                {"aspect_title": "<string>", "content": "<string>"}
+            ],
+            "conclusion": "<string>",
+            "sources": [
+                {"title": "<string>", "url": "<string>", "tool_used": "<string>"}
+            ]
+        }
+        json_schema = json.dumps(schema_example, ensure_ascii=False, indent=2)
+        # 간단한 스니펫 요약을 하나의 문자열로 병합
+        snippets_text = "\n".join(
+            f"- [{s.get('source_domain','N/A')}] {s.get('title','')} — {s.get('snippet','')} ({s.get('url','')})"
+            for s in snippets
+        )
+        return f"""
+You are an expert research report generation agent.
+Use the following inputs to write a detailed, structured report in JSON.
+Write all text content in Korean (한국어로 작성하세요).
+
+# Inputs
+Original Query: "{original_query}"
+Refined Core Question: "{refined_intent}"
+Context Snippets (up to {len(snippets)} items):
+{snippets_text}
+
+# Output Format
+Return ONLY valid JSON matching the schema below, NO think tags, NO explanation, NO comments.
+
+{json_schema}
+"""
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        query_sec = state.query
+        search_sec = state.search
+        config_sec = state.config
+
+        node_name = self.__class__.__name__
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+        writer_id = config_sec.config.get("writer_id", "default_writer")
+
+        extra = {
+            "trace_id": trace_id,
+            "comic_id": comic_id,
+            "node": node_name,
+        }
+        logger.info("Entering N05ReportGenerationNode", extra=extra)
+
+        original_query = query_sec.original_query
+        refined_intent = query_sec.query_context.get("refined_intent", original_query)
+        raw_results = search_sec.raw_search_results or []
+
+        # 스니펫 객체 준비 (최대 5개)
+        snippets = []
+        for item in raw_results[:5]:
+            snippets.append({
+                "title": item.get("title", ""),
+                "snippet": item.get("snippet", ""),
+                "url": item.get("url", ""),
+                "source_domain": item.get("source", item.get("source_domain", "N/A"))
+            })
+
+        # 1) 한 번의 LLM 호출로 JSON 생성
+        system_prompt = self._build_system_prompt(original_query, refined_intent, snippets)
+        # qwen3 사용 시 prompt 인자는 간단히 Refined Intent 정도로 활용
+        llm_resp = await self.llm_service.generate_text(
+            system_prompt_content=system_prompt,
+            prompt=refined_intent,
+            temperature=0.3,
+            max_tokens=3000,
+        )
+        raw_txt = llm_resp.get("generated_text", "")
+        logger.debug("Raw LLM response for report JSON: %s", raw_txt, extra=extra)
+
+        # 2) JSON 파싱
+        try:
+            report_json = extract_json(raw_txt)
+        except Exception as e:
+            logger.error("Failed to parse report JSON: %s", e, extra=extra)
+            meta.current_stage = "ERROR"
+            meta.error_message = f"JSON parsing error in N05: {e}"
+            return {"meta": meta.model_dump()}
+
+        # 3) Jinja2로 HTML 렌더링
+        report_data = {
+            "title": report_json.get("title", ""),
+            "original_query": original_query,
+            "refined_intent": refined_intent,
+            "introduction": report_json.get("introduction", ""),
+            "sections": report_json.get("sections", []),
+            "conclusion": report_json.get("conclusion", ""),
+            "sources": report_json.get("sources", []),
+            "generation_timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+            "writer_id": writer_id,
+        }
+
+        try:
+            template = self.jinja_env.get_template(self.template_name)
+            html = template.render(report_data)
+            state.report.report_content = html
+            meta.current_stage = "n06_finalize_report"
+            logger.info("Report HTML successfully rendered.", extra=extra)
+        except Exception as e:
+            logger.error("Failed to render report template: %s", e, extra=extra)
+            meta.current_stage = "ERROR"
+            meta.error_message = f"Template rendering error in N05: {e}"
+            state.report.report_content = ""
+
+        return {
+            "report": state.report.model_dump(),
+            "meta": meta.model_dump(),
+        }

--- a/app/nodes_v2/n05_report_generation_node.py
+++ b/app/nodes_v2/n05_report_generation_node.py
@@ -109,8 +109,11 @@ class N05ReportGenerationNode:
         )
         return f"""
 You are an expert research report generation agent.
-Use the following inputs to write a detailed, structured report in JSON.
-Write all text content in Korean (한국어로 작성하세요).
+Using the provided search snippets, write a detailed and structured report in JSON format.
+Write in natural Korean (한국어로 작성하세요), targeting a professional but non-specialist audience (e.g., tech readers, policymakers, advanced students).
+
+Each 'section' in the JSON should consist of 3 to 5 well-developed paragraphs (~300+ words), clearly explaining the key aspect with relevant facts, analysis, and examples.
+Avoid vague statements or generic text. Emphasize clarity and insight.
 
 # Inputs
 Original Query: "{original_query}"
@@ -118,9 +121,9 @@ Refined Core Question: "{refined_intent}"
 Context Snippets (up to {len(snippets)} items):
 {snippets_text}
 
-# Output Format
 Return ONLY valid JSON matching the schema below, NO think tags, NO explanation, NO comments.
 
+# Output Format
 {json_schema}
 """
 
@@ -163,7 +166,7 @@ Return ONLY valid JSON matching the schema below, NO think tags, NO explanation,
             system_prompt_content=system_prompt,
             prompt=refined_intent,
             temperature=0.3,
-            max_tokens=3000,
+            max_tokens=4096,
         )
         raw_txt = llm_resp.get("generated_text", "")
         logger.debug("Raw LLM response for report JSON: %s", raw_txt, extra=extra)

--- a/app/nodes_v2/n06_save_report_node.py
+++ b/app/nodes_v2/n06_save_report_node.py
@@ -1,0 +1,99 @@
+# ai/app/nodes/n06_save_report_node.py
+
+import traceback
+from pathlib import Path
+from typing import Dict, Any, Optional
+from datetime import datetime, timezone
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, PROJECT_ROOT
+from app.config.settings import Settings
+
+logger = get_logger(__name__)
+settings = Settings()
+
+DEFAULT_RESULTS_BASE_DIR = PROJECT_ROOT / "results"
+
+
+class N06SaveReportNode:
+    """
+    N05에서 생성된 보고서 내용을 로컬 파일 시스템에 저장하는 노드.
+    (Qwen3가 한국어로 출력하기 때문에 별도 번역은 수행하지 않음)
+    """
+
+    def __init__(self, results_base_dir: Optional[Path] = None):
+        """
+        노드 초기화.
+
+        Args:
+            results_base_dir (Optional[Path]): 보고서를 저장할 기본 디렉토리 경로.
+                                               None이면 기본값(PROJECT_ROOT/results) 사용.
+        """
+        self.results_base_dir = results_base_dir or DEFAULT_RESULTS_BASE_DIR
+        logger.info(f"N06: Report save directory base set to: {self.results_base_dir}")
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        """
+        보고서 내용을 파일로 저장합니다.
+        """
+        meta = state.meta
+        report_sec = state.report
+        node_name = self.__class__.__name__
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+        report_content = report_sec.report_content
+        error_log = list(meta.error_log or [])
+
+        extra_log_data = {'trace_id': trace_id, 'comic_id': comic_id, 'node_name': node_name}
+        logger.info(f"N06: Entering node. Attempting to save report content.", extra=extra_log_data)
+
+        if not comic_id:
+            error_msg = "Comic ID is missing, cannot determine save path."
+            logger.error(error_msg, extra=extra_log_data)
+            error_log.append({
+                "stage": node_name,
+                "error": error_msg,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            })
+            meta.current_stage = "ERROR"
+            meta.error_log = error_log
+            meta.error_message = error_msg
+            return {"report": report_sec.model_dump(), "meta": meta.model_dump()}
+
+        if not report_content or not isinstance(report_content, str):
+            error_msg = "Report content is missing or not a string. Nothing to save."
+            logger.warning(error_msg, extra=extra_log_data)
+            meta.current_stage = "DONE"
+            report_sec.saved_report_path = None
+            return {"report": report_sec.model_dump(), "meta": meta.model_dump()}
+
+        try:
+            report_dir = self.results_base_dir / comic_id
+            report_dir.mkdir(parents=True, exist_ok=True)
+            report_path = report_dir / "report.html"
+
+            with open(report_path, "w", encoding="utf-8") as f:
+                f.write(report_content)
+
+            saved_path_str = str(report_path.resolve())
+            logger.info(f"N06: Report successfully saved to: {saved_path_str}", extra=extra_log_data)
+            report_sec.saved_report_path = saved_path_str
+
+            meta.current_stage = "DONE"
+            meta.error_log = error_log
+            return {"report": report_sec.model_dump(), "meta": meta.model_dump()}
+
+        except Exception as e:
+            error_msg = f"N06: Error while saving report: {e}"
+            logger.exception(error_msg, extra=extra_log_data)
+            error_log.append({
+                "stage": node_name,
+                "error": error_msg,
+                "detail": traceback.format_exc(),
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            })
+            meta.current_stage = "ERROR"
+            meta.error_log = error_log
+            meta.error_message = error_msg
+            report_sec.saved_report_path = None
+            return {"report": report_sec.model_dump(), "meta": meta.model_dump()}

--- a/app/nodes_v2/n06_save_report_node.py
+++ b/app/nodes_v2/n06_save_report_node.py
@@ -1,4 +1,4 @@
-# ai/app/nodes/n06_save_report_node.py
+# ai/app/nodes_v2/n06_save_report_node.py
 
 import traceback
 from pathlib import Path

--- a/app/nodes_v2/n06b_contextual_summary_node.py
+++ b/app/nodes_v2/n06b_contextual_summary_node.py
@@ -59,7 +59,7 @@ Each insight should be a concise sentence or short paragraph (20~40 words).
 {report_text[:8000]}
 
 # Output Format
-Return ONLY valid JSON matching this schema, with key "contextual_summary" and an array of strings:
+Return ONLY valid JSON matching the schema and key "contextual_summary" below, NO think tags, NO explanation, NO comments.:
 {json_schema}
 """
 

--- a/app/nodes_v2/n06b_contextual_summary_node.py
+++ b/app/nodes_v2/n06b_contextual_summary_node.py
@@ -1,0 +1,135 @@
+import json
+import re
+import traceback
+from typing import Dict, Any, List
+from datetime import datetime, timezone
+
+from app.utils.logger import get_logger, summarize_for_logging
+from app.workflows.state_v2 import WorkflowState
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+
+logger = get_logger(__name__)
+
+class N06BContextualSummaryNode:
+    """
+    (업그레이드됨) 보고서 내용을 refined_intent, category 및 audience에 맞춰 요약하여
+    구조화된 JSON으로 반환하고, 이를 다시 markdown bullet list 형식으로 저장하는 노드.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _strip_html(self, html_content: str) -> str:
+        text = re.sub(r'<[^>]+>', ' ', html_content)
+        return re.sub(r'\s+', ' ', text).strip()
+
+    def _build_summary_prompt(
+        self,
+        report_text: str,
+        refined_intent: str,
+        category: str,
+        audience: str
+    ) -> str:
+        # JSON 스키마 예시
+        schema_example = {
+            "contextual_summary": [
+                "<핵심 인사이트 1>",
+                "<핵심 인사이트 2>",
+                "<핵심 인사이트 3>"
+            ]
+        }
+        json_schema = json.dumps(schema_example, ensure_ascii=False, indent=2)
+        # 프롬프트 구성
+        return f"""
+You are an expert summarization assistant.
+Generate a contextual summary of the report in valid JSON only.
+Write in clear Korean (한국어로 작성하세요). Use bullet points converted into a JSON array.
+
+# Context
+- Refined Intent: {refined_intent}
+- Category: {category}
+- Audience: {audience}
+
+# Task
+Summarize the following report into 3~5 core insights.
+Each insight should be a concise sentence or short paragraph (20~40 words).
+
+# Report Content
+{report_text[:8000]}
+
+# Output Format
+Return ONLY valid JSON matching this schema, with key "contextual_summary" and an array of strings:
+{json_schema}
+"""
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        report_sec = state.report
+        query_sec = state.query
+        config_sec = state.config
+        node_name = self.__class__.__name__
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+        extra = {"trace_id": trace_id, "comic_id": comic_id, "node_name": node_name}
+
+        logger.info(
+            f"Entering {node_name}. Generating contextual summary.",
+            extra=extra
+        )
+        error_log = list(meta.error_log or [])
+
+        try:
+            if not report_sec.report_content:
+                raise ValueError("report_content is missing")
+
+            # HTML 제거
+            report_text = self._strip_html(report_sec.report_content)
+            refined_intent = query_sec.query_context.get("refined_intent", query_sec.original_query)
+            category = query_sec.query_context.get("query_category", "Other")
+            audience = config_sec.config.get("target_audience", "general_public")
+
+            # 프롬프트 생성 및 LLM 호출
+            prompt = self._build_summary_prompt(report_text, refined_intent, category, audience)
+            llm_resp = await self.llm_service.generate_text(
+                system_prompt_content=prompt,
+                prompt=refined_intent,
+                max_tokens=800,
+                temperature=0.3
+            )
+            raw_txt = llm_resp.get("generated_text", "")
+            logger.debug(f"Raw summary JSON: {raw_txt}", extra=extra)
+
+            # JSON 파싱
+            parsed = extract_json(raw_txt)
+            summary_items = parsed.get("contextual_summary", [])
+            if not isinstance(summary_items, list):
+                raise ValueError("Parsed JSON 'contextual_summary' is not a list")
+
+            # Markdown bullet list 형태로 변환
+            summary_text = "\n".join([f"- {item}" for item in summary_items])
+            report_sec.contextual_summary = summary_text
+
+            # 메타 업데이트
+            meta.current_stage = "n07_comic_ideation"
+            meta.error_log = error_log
+            logger.info(
+                f"Contextual summary generated: {summary_items[:3]}...",
+                extra=extra
+            )
+
+            return {"report": report_sec.model_dump(), "meta": meta.model_dump()}
+
+        except Exception as e:
+            error_msg = f"Error in {node_name}: {e}"
+            logger.exception(error_msg, extra=extra)
+            error_log.append({
+                "stage": node_name,
+                "error": str(e),
+                "detail": traceback.format_exc(),
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            })
+            meta.current_stage = "ERROR"
+            meta.error_log = error_log
+            meta.error_message = error_msg
+            return {"report": report_sec.model_dump(), "meta": meta.model_dump()}

--- a/app/nodes_v2/n06b_contextual_summary_node.py
+++ b/app/nodes_v2/n06b_contextual_summary_node.py
@@ -1,3 +1,4 @@
+# ai/app/nodes_v2/n06b_contextual_summary_node.py
 import json
 import re
 import traceback

--- a/app/nodes_v2/n07_comic_ideation_node.py
+++ b/app/nodes_v2/n07_comic_ideation_node.py
@@ -63,7 +63,10 @@ System Prompt:
 
 Generate 3 to {MAX_INSIGHTS} key insights in JSON only.
 Write in clear Korean (한국어로 작성하세요).
-Output format (JSON only):
+
+Return ONLY valid JSON matching the schema below, NO think tags, NO explanation, NO comments.
+
+Output format:
 {schema}
 
 User Context:
@@ -78,7 +81,7 @@ Report Summary:
             system_prompt_content=prompt,
             prompt=refined_intent,
             temperature=0.3,
-            max_tokens=500
+            max_tokens=1000
         )
         raw = response.get("generated_text", "")
         logger.debug(f"Raw insights JSON: {raw}", extra=extra)
@@ -135,7 +138,7 @@ Key Insights:
             system_prompt_content=prompt,
             prompt=refined_intent,
             temperature=0.7,
-            max_tokens=1000
+            max_tokens=1500
         )
         raw = response.get("generated_text", "")
         logger.debug(f"Raw ideas JSON: {raw}", extra=extra)

--- a/app/nodes_v2/n07_comic_ideation_node.py
+++ b/app/nodes_v2/n07_comic_ideation_node.py
@@ -1,3 +1,4 @@
+# ai/app/nodes_v2/n07_comic_ideation_node.py
 import re
 import traceback
 from typing import Any, Dict, List, Optional

--- a/app/nodes_v2/n07_comic_ideation_node.py
+++ b/app/nodes_v2/n07_comic_ideation_node.py
@@ -1,0 +1,197 @@
+import re
+import traceback
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+
+logger = get_logger(__name__)
+
+# 최대 처리할 보고서 요약 길이
+MAX_REPORT_CHARS = 4000
+MAX_INSIGHTS = 5
+MAX_IDEAS = 3
+
+class N07ComicIdeationNode:
+    """
+    (업그레이드됨) N06A가 생성한 contextual_summary 또는 보고서 본문을 사용해,
+    핵심 인사이트와 만화 아이디어를 JSON으로 생성하는 노드.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _strip_html(self, html_content: str) -> str:
+        # 간단한 HTML 태그 제거
+        text = re.sub(r'<[^>]+>', ' ', html_content)
+        return re.sub(r'\s+', ' ', text).strip()
+
+    async def _get_report_text(self, report_html: str, contextual: Optional[str], trace_id: str, extra: Dict) -> str:
+        """
+        contextual_summary가 있으면 사용, 그렇지 않으면 HTML을 텍스트로 변환하여 반환.
+        적절히 길이를 제한.
+        """
+        if contextual:
+            logger.info("Using contextual_summary from N06A.", extra=extra)
+            text = contextual.strip()
+        else:
+            text = self._strip_html(report_html)
+        # 길이 제한
+        if len(text) > MAX_REPORT_CHARS:
+            text = text[:MAX_REPORT_CHARS] + '...'
+        return text
+
+    async def _extract_key_insights(self,
+            summary: str, refined_intent: str, category: str, audience: str,
+            trace_id: str, extra: Dict[str, Any]
+    ) -> List[str]:
+        """
+        핵심 인사이트를 JSON 배열로 요청하고, 파싱하여 Python 리스트로 반환.
+        """
+        system_prompt = (
+            "You are an analytical assistant. Extract the most critical insights "
+            "directly addressing the user's refined question."
+        )
+        # 프롬프트에 JSON 스키마 명시
+        schema = {"insights": ["<string>"]}
+        prompt = f"""
+System Prompt:
+{system_prompt}
+
+Generate 3 to {MAX_INSIGHTS} key insights in JSON only.
+Write in clear Korean (한국어로 작성하세요).
+Output format (JSON only):
+{schema}
+
+User Context:
+- Refined Question: {refined_intent}
+- Category: {category}
+- Audience: {audience}
+
+Report Summary:
+{summary}
+"""
+        response = await self.llm_service.generate_text(
+            system_prompt_content=prompt,
+            prompt=refined_intent,
+            temperature=0.3,
+            max_tokens=500
+        )
+        raw = response.get("generated_text", "")
+        logger.debug(f"Raw insights JSON: {raw}", extra=extra)
+        try:
+            parsed = extract_json(raw)
+            insights = parsed.get("insights", [])
+            if isinstance(insights, list):
+                return insights[:MAX_INSIGHTS]
+        except Exception as e:
+            logger.error(f"Failed to parse insights JSON: {e}", extra=extra)
+        # fallback: 빈 리스트 반환
+        return []
+
+    async def _generate_comic_ideas(
+            self,
+            insights: List[str], refined_intent: str,
+            original_query: str, category: str,
+            audience: str, trace_id: str, extra: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """
+        인사이트를 바탕으로 JSON 형태의 만화 아이디어 리스트를 생성.
+        """
+        system_prompt = (
+            "You are a creative comic-idea generator. "
+            "Generate ideas formatted as valid JSON only."
+        )
+        # JSON 스키마 예시
+        schema = {"ideas": [{
+            "title": "<string>",
+            "logline": "<string>",
+            "genre": "<string>",
+            "target_emotion": "<string>",
+            "key_elements": ["<string>"]
+        }]}
+        # 인사이트 포맷 문자열
+        insights_text = '\n'.join([f"- {i}" for i in insights])
+        prompt = f"""
+System Prompt:
+{system_prompt}
+
+Generate exactly {MAX_IDEAS} unique comic ideas following this JSON schema only:
+{schema}
+
+User Context:
+- Original Query: {original_query}
+- Refined Question: {refined_intent}
+- Category: {category}
+- Audience: {audience}
+
+Key Insights:
+{insights_text}
+"""
+        response = await self.llm_service.generate_text(
+            system_prompt_content=prompt,
+            prompt=refined_intent,
+            temperature=0.7,
+            max_tokens=1000
+        )
+        raw = response.get("generated_text", "")
+        logger.debug(f"Raw ideas JSON: {raw}", extra=extra)
+        try:
+            parsed = extract_json(raw)
+            ideas = parsed.get("ideas", [])
+            if isinstance(ideas, list):
+                return ideas[:MAX_IDEAS]
+        except Exception as e:
+            logger.error(f"Failed to parse ideas JSON: {e}", extra=extra)
+        # fallback: 빈 리스트 반환
+        return []
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        idea_sec = state.idea
+        report_sec = state.report
+        query_sec = state.query
+        config = state.config.config or {}
+        node_name = self.__class__.__name__
+        extra = {'trace_id': meta.trace_id, 'comic_id': meta.comic_id, 'node_name': node_name}
+        logger.info(f"Entering {node_name}.", extra=extra)
+        error_log = list(meta.error_log or [])
+
+        # 1) 보고서 텍스트 준비
+        report_text = await self._get_report_text(
+            report_sec.report_content,
+            getattr(report_sec, 'contextual_summary', None),
+            meta.trace_id, extra
+        )
+        if not report_text:
+            error_msg = "Report text is empty."
+            logger.error(error_msg, extra=extra)
+            error_log.append({'stage': node_name, 'error': error_msg, 'timestamp': datetime.now(timezone.utc).isoformat()})
+            meta.current_stage = 'ERROR'
+            meta.error_log = error_log
+            return {'idea': idea_sec.model_dump(), 'meta': meta.model_dump()}
+
+        # 2) 핵심 인사이트 추출
+        refined_intent = query_sec.query_context.get('refined_intent', query_sec.original_query)
+        category = query_sec.query_context.get('query_category', 'Other')
+        audience = config.get('target_audience', 'general_public')
+        insights = await self._extract_key_insights(
+            report_text, refined_intent, category, audience,
+            meta.trace_id, extra
+        )
+
+        # 3) 만화 아이디어 생성
+        ideas = await self._generate_comic_ideas(
+            insights, refined_intent,
+            query_sec.original_query, category,
+            audience, meta.trace_id, extra
+        )
+
+        idea_sec.comic_ideas = ideas
+        meta.current_stage = 'n08_scenario_generation'
+        meta.error_log = error_log
+        logger.info(f"Generated {len(ideas)} comic ideas.", extra=extra)
+        return {'idea': idea_sec.model_dump(), 'meta': meta.model_dump()}

--- a/app/nodes_v2/n08_scenario_generation_node.py
+++ b/app/nodes_v2/n08_scenario_generation_node.py
@@ -1,3 +1,4 @@
+# ai/app/nodes_v2/n08_scenario_generation_node.py
 import json
 import re
 from datetime import datetime, timezone

--- a/app/nodes_v2/n08_scenario_generation_node.py
+++ b/app/nodes_v2/n08_scenario_generation_node.py
@@ -1,0 +1,130 @@
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+
+logger = get_logger(__name__)
+
+class N08ScenarioGenerationNode:
+    """
+    (업그레이드됨) 단일 LLM 호출로 썸네일 프롬프트와 4패널 웹툰 시나리오를
+    JSON으로 생성하여 state.scenario에 저장하는 노드.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _build_system_prompt(
+        self,
+        idea: Dict[str, Any],
+        summary: str,
+        audience: str
+    ) -> str:
+        """
+        시나리오 및 썸네일 프롬프트를 생성할 LLM system prompt 구성
+        """
+        schema_example = {
+            "thumbnail_prompt": "<string>",
+            "panels": [
+                {
+                    "panel_number": 1,
+                    "scene_identifier": "S01P01",
+                    "setting": "<string>",
+                    "characters_present": "<string>",
+                    "camera_shot_and_angle": "<string>",
+                    "key_actions_or_events": "<string>",
+                    "lighting_and_atmosphere": "<string>",
+                    "dialogue_summary_for_image_context": "<string>",
+                    "visual_effects_or_key_props": "<string>",
+                    "image_style_notes_for_scene": "<string>",
+                    "final_image_prompt": "<string>"
+                }
+            ]
+        }
+        json_schema = json.dumps(schema_example, ensure_ascii=False, indent=2)
+
+        title = idea.get("title", "Untitled Comic")
+        logline = idea.get("logline") or idea.get("summary", "No summary provided.")
+        genre = idea.get("genre", "general")
+
+        return f"""
+You are a professional webtoon scenario writer and AI image prompt engineer.
+Generate both a thumbnail image prompt and a detailed 4-panel scenario for the given comic idea.
+Write in clear Korean (한국어로 작성하세요).
+
+# Comic Idea
+Title: {title}
+Logline: {logline}
+Genre: {genre}
+Target Audience: {audience}
+
+# Context Summary
+{summary}
+
+# Output Format (Strict JSON only)
+Return ONLY valid JSON matching this schema exactly, without explanations, comments, or markdown:
+{json_schema}
+"""  # noqa: E501
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        scenario_sec = state.scenario
+        idea_sec = state.idea
+        report_sec = state.report
+
+        # 1) 아이디어 선택
+        selected = scenario_sec.selected_comic_idea_for_scenario or (idea_sec.comic_ideas or [None])[0]
+        if not isinstance(selected, dict):
+            logger.error("유효한 comic_idea가 없습니다.", extra={"trace_id": meta.trace_id})
+            meta.current_stage = "ERROR"
+            meta.error_message = "No comic idea provided for scenario generation"
+            return {"scenario": scenario_sec.model_dump(), "meta": meta.model_dump()}
+
+        # 2) 요약 또는 보고서 텍스트 준비
+        summary = getattr(report_sec, "contextual_summary", None)
+        if not summary:
+            summary = re.sub(r'<[^>]+>', ' ', report_sec.report_content or '')
+            summary = ' '.join(summary.split())[:4000]
+
+        audience = state.config.config.get("target_audience", "general_public")
+
+        # 3) System prompt 생성 & LLM 호출
+        system_prompt = self._build_system_prompt(selected, summary, audience)
+        llm_resp = await self.llm_service.generate_text(
+            system_prompt_content=system_prompt,
+            prompt="",
+            max_tokens=3500,
+            temperature=0.7
+        )
+        raw = llm_resp.get("generated_text", "")
+        logger.debug(f"Raw scenario JSON: {raw}", extra={"trace_id": meta.trace_id})
+
+        # 4) JSON 파싱
+        try:
+            parsed = extract_json(raw)
+        except Exception as e:
+            logger.error(f"JSON 파싱 실패: {e}", extra={"trace_id": meta.trace_id})
+            meta.current_stage = "ERROR"
+            meta.error_message = f"Scenario JSON parsing error: {e}"
+            return {"scenario": scenario_sec.model_dump(), "meta": meta.model_dump()}
+
+        # 5) State 업데이트
+        thumbnail = parsed.get("thumbnail_prompt", "")
+        panels = parsed.get("panels", [])
+
+        scenario_sec.thumbnail_image_prompt = thumbnail
+        scenario_sec.comic_scenarios = panels
+
+        meta.current_stage = "n09_image_generation"
+        meta.error_log = list(meta.error_log or [])
+
+        logger.info(
+            f"Scenario 생성 완료: {len(panels)} panels, thumbnail length {len(thumbnail)}", 
+            extra={"trace_id": meta.trace_id}
+        )
+        return {"scenario": scenario_sec.model_dump(), "meta": meta.model_dump()}

--- a/app/nodes_v2/n08_scenario_generation_node.py
+++ b/app/nodes_v2/n08_scenario_generation_node.py
@@ -19,14 +19,9 @@ class N08ScenarioGenerationNode:
     def __init__(self, llm_service: LLMService):
         self.llm_service = llm_service
 
-    def _build_system_prompt(
-        self,
-        idea: Dict[str, Any],
-        summary: str,
-        audience: str
-    ) -> str:
+    def _build_system_prompt(self) -> str:
         """
-        시나리오 및 썸네일 프롬프트를 생성할 LLM system prompt 구성
+        4개의 패널 예시를 모두 나열한 JSON 스키마를 시스템 프롬프트에 포함합니다.
         """
         schema_example = {
             "thumbnail_prompt": "<string>",
@@ -43,33 +38,76 @@ class N08ScenarioGenerationNode:
                     "visual_effects_or_key_props": "<string>",
                     "image_style_notes_for_scene": "<string>",
                     "final_image_prompt": "<string>"
+                },
+                {
+                    "panel_number": 2,
+                    "scene_identifier": "S01P02",
+                    "setting": "<string>",
+                    "characters_present": "<string>",
+                    "camera_shot_and_angle": "<string>",
+                    "key_actions_or_events": "<string>",
+                    "lighting_and_atmosphere": "<string>",
+                    "dialogue_summary_for_image_context": "<string>",
+                    "visual_effects_or_key_props": "<string>",
+                    "image_style_notes_for_scene": "<string>",
+                    "final_image_prompt": "<string>"
+                },
+                {
+                    "panel_number": 3,
+                    "scene_identifier": "S01P03",
+                    "setting": "<string>",
+                    "characters_present": "<string>",
+                    "camera_shot_and_angle": "<string>",
+                    "key_actions_or_events": "<string>",
+                    "lighting_and_atmosphere": "<string>",
+                    "dialogue_summary_for_image_context": "<string>",
+                    "visual_effects_or_key_props": "<string>",
+                    "image_style_notes_for_scene": "<string>",
+                    "final_image_prompt": "<string>"
+                },
+                {
+                    "panel_number": 4,
+                    "scene_identifier": "S01P04",
+                    "setting": "<string>",
+                    "characters_present": "<string>",
+                    "camera_shot_and_angle": "<string>",
+                    "key_actions_or_events": "<string>",
+                    "lighting_and_atmosphere": "<string>",
+                    "dialogue_summary_for_image_context": "<string>",
+                    "visual_effects_or_key_props": "<string>",
+                    "image_style_notes_for_scene": "<string>",
+                    "final_image_prompt": "<string>"
                 }
             ]
         }
         json_schema = json.dumps(schema_example, ensure_ascii=False, indent=2)
 
+        return (
+            "You are a professional webtoon scenario writer and AI image prompt engineer.\n"
+            "Generate both a thumbnail image prompt and exactly 4 detailed panels for the given comic idea.\n"
+            "Write in clear Korean (한국어로 작성하세요).\n"
+            "Return ONLY valid JSON matching the schema below, NO think tags, NO explanation, NO comments.\n"
+            "# Output Format\n"
+            f"{json_schema}"
+        )
+
+
+    def _build_user_prompt(self, idea: Dict[str, Any], summary: str, audience: str) -> str:
+        """
+        실제 입력 데이터(아이디어, summary, audience 등)는 user prompt에 넣습니다.
+        """
         title = idea.get("title", "Untitled Comic")
         logline = idea.get("logline") or idea.get("summary", "No summary provided.")
         genre = idea.get("genre", "general")
-
-        return f"""
-You are a professional webtoon scenario writer and AI image prompt engineer.
-Generate both a thumbnail image prompt and a detailed 4-panel scenario for the given comic idea.
-Write in clear Korean (한국어로 작성하세요).
-
-# Comic Idea
-Title: {title}
-Logline: {logline}
-Genre: {genre}
-Target Audience: {audience}
-
-# Context Summary
-{summary}
-
-# Output Format (Strict JSON only)
-Return ONLY valid JSON matching this schema exactly, without explanations, comments, or markdown:
-{json_schema}
-"""  # noqa: E501
+        return (
+            f"# Comic Idea\n"
+            f"Title: {title}\n"
+            f"Logline: {logline}\n"
+            f"Genre: {genre}\n"
+            f"Target Audience: {audience}\n\n"
+            f"# Context Summary\n"
+            f"{summary}"
+        )
 
     async def run(self, state: WorkflowState) -> Dict[str, Any]:
         meta = state.meta
@@ -93,38 +131,67 @@ Return ONLY valid JSON matching this schema exactly, without explanations, comme
 
         audience = state.config.config.get("target_audience", "general_public")
 
-        # 3) System prompt 생성 & LLM 호출
-        system_prompt = self._build_system_prompt(selected, summary, audience)
-        llm_resp = await self.llm_service.generate_text(
-            system_prompt_content=system_prompt,
-            prompt="",
-            max_tokens=3500,
-            temperature=0.7
-        )
-        raw = llm_resp.get("generated_text", "")
-        logger.debug(f"Raw scenario JSON: {raw}", extra={"trace_id": meta.trace_id})
+        # 3) system / user prompt 분리
+        system_prompt = self._build_system_prompt()
+        user_prompt = self._build_user_prompt(selected, summary, audience)
 
-        # 4) JSON 파싱
-        try:
-            parsed = extract_json(raw)
-        except Exception as e:
-            logger.error(f"JSON 파싱 실패: {e}", extra={"trace_id": meta.trace_id})
+        # 4) LLM 호출 + 재시도 로직 (파싱 후 패널 수 검증)
+        max_retries = 2
+        for attempt in range(max_retries + 1):
+            logger.info(f"Generating scenario for {selected.get('title')}", extra={"trace_id": meta.trace_id})
+            llm_resp = await self.llm_service.generate_text(
+                system_prompt_content=system_prompt,
+                prompt=user_prompt,
+                max_tokens=3500,
+                temperature=0.7
+            )
+            raw = llm_resp.get("generated_text", "")
+            logger.debug(f"Raw scenario JSON: {raw}", extra={"trace_id": meta.trace_id})
+            if not raw or "error" in llm_resp:
+                logger.warning(f"LLM 응답 실패, 재시도 {attempt+1}/{max_retries+1}", extra={"trace_id": meta.trace_id})
+                continue
+
+            # JSON 파싱
+            try:
+                parsed = extract_json(raw)
+            except Exception as e:
+                logger.error(f"JSON 파싱 실패: {e}", extra={"trace_id": meta.trace_id})
+                continue
+
+            # 패널 수 검증: 반드시 4개여야 함
+            panels = parsed.get("panels", [])
+            if not isinstance(panels, list) or len(panels) != 4:
+                logger.warning(
+                    f"잘못된 패널 수({len(panels)}) – 정확히 4개의 패널 필요, 재시도 {attempt+1}/{max_retries+1}",
+                    extra={"trace_id": meta.trace_id}
+                )
+                continue
+
+            # 썸네일도 반드시 문자열이어야 함
+            thumbnail = parsed.get("thumbnail_prompt")
+            if not isinstance(thumbnail, str) or not thumbnail.strip():
+                logger.warning(
+                    "썸네일 프롬프트가 비어있거나 유효하지 않음 – 재시도 "
+                    f"{attempt+1}/{max_retries+1}", extra={"trace_id": meta.trace_id}
+                )
+                continue
+
+            # 성공
+            break
+        else:
+            # 모든 시도 실패 시 에러
             meta.current_stage = "ERROR"
-            meta.error_message = f"Scenario JSON parsing error: {e}"
+            meta.error_message = "Scenario generation failed after retries (invalid structure)"
             return {"scenario": scenario_sec.model_dump(), "meta": meta.model_dump()}
 
         # 5) State 업데이트
-        thumbnail = parsed.get("thumbnail_prompt", "")
-        panels = parsed.get("panels", [])
-
         scenario_sec.thumbnail_image_prompt = thumbnail
         scenario_sec.comic_scenarios = panels
 
         meta.current_stage = "n09_image_generation"
         meta.error_log = list(meta.error_log or [])
-
         logger.info(
-            f"Scenario 생성 완료: {len(panels)} panels, thumbnail length {len(thumbnail)}", 
+            f"Scenario 생성 완료: {len(panels)} panels, thumbnail length {len(thumbnail)}",
             extra={"trace_id": meta.trace_id}
         )
         return {"scenario": scenario_sec.model_dump(), "meta": meta.model_dump()}

--- a/app/nodes_v2/n08a_image_prompt_refine_node.py
+++ b/app/nodes_v2/n08a_image_prompt_refine_node.py
@@ -1,0 +1,204 @@
+# ai/app/nodes/n08a_image_prompt_refinement_node.py
+
+import json
+from typing import Dict, Any, List
+
+from app.workflows.state_v2 import WorkflowState
+from app.services.llm_service import LLMService
+from app.tools.think_parser_tool import extract_json
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class N08aImagePromptRefinementNode:
+    """
+    n08 에서 생성된 thumbnail_prompt, panels 시나리오를
+    1) 정규화·표준화 → 2) Flux/XL 모드별로 재구성
+    두 번의 LLM 호출로 처리하여 ImageSection.generated_comic_images에 저장합니다.
+    """
+
+    def __init__(self, llm_service: LLMService):
+        self.llm_service = llm_service
+
+    def _build_system_prompt_normalization(self) -> str:
+        return """
+You are an expert image-prompt normalizer.
+- 입력된 한국어/영어 문장을 모두 영어로 통일하고
+- 브랜드명, 고유명사, 모호한 단어 등을 일반화(normalize)하세요.
+- 결과는 JSON으로, 아래 스키마만 반환합니다.
+
+Schema:
+{
+  "thumbnail_prompt": "<string>",
+  "panels": ["<string>", "<string>", "<string>", "<string>"]
+}
+"""
+
+    def _build_user_prompt_normalization(self, thumbnail: str, panels: List[Dict[str, Any]]) -> str:
+        panels_text = "\n".join(
+            f"- {p.get('scene_identifier')}: {p.get('final_image_prompt','')}"
+            for p in panels
+        )
+        return f"""
+Return only JSON, NO thinks, NO comments, NO explanations.
+# Original Thumbnail Prompt
+{thumbnail}
+
+# Original Panel Prompts
+{panels_text}
+"""
+
+    def _build_system_prompt_flux(self) -> str:
+        # 예시로 넣은 Flux-Ghibli 포맷을 few-shot 예제로 포함
+        example_prompt = (
+            "A young boy with bright orange hair and a mischievous grin is riding on the back of a large, fluffy bear through the village. "
+            "The bear has a thick white coat and moves gracefully through the cobbled streets. The villagers watch in surprise and amusement. "
+            "The sky is clear, and the village is alive with activity. The camera is at eye level, capturing the joyful boy and the bear as they move through the village."
+        )
+        return f"""
+You are an expert image prompt engineer for narrative style (Flux).
+Below is a normalized thumbnail & panels. Produce for each a **fully descriptive English sentence** suitable for Flux-Ghibli–style image generation.
+Use the same structure/order as the example:
+
+# Example (thumbnail or panel)
+{example_prompt}
+
+# Output Schema (JSON only):
+{{
+  "thumbnail_prompt": "<string>",
+  "panel_prompts": ["<string>", "<string>", "<string>", "<string>"]
+}}
+"""
+
+    def _build_system_prompt_xl(self) -> str:
+        # 예시로 넣은 AnythingXL 단어 집합을 few-shot 예제로 포함
+        example_tokens = [
+            "masterpiece", "best quality", "1girl", "solo", "animal ears", 
+            "bow", "teeth", "jacket", "tail", "open mouth"
+        ]
+        example_line = ", ".join(example_tokens)
+        return f"""
+You are an expert image prompt engineer for token-based style (XL).
+Below is a normalized thumbnail & panels. For each, produce a **comma-separated list of keywords** in English, following the **order** and style shown:
+
+# Example Tokens:
+{example_line}
+
+# Output Schema (JSON only):
+{{
+  "thumbnail_tokens": ["<string>", ...],
+  "panel_tokens": [
+     ["<string>", ...],
+     ["<string>", ...],
+     ["<string>", ...],
+     ["<string>", ...]
+  ]
+}}
+"""
+
+    def _build_user_prompt_mode(self, thumbnail: str, panels: List[str]) -> str:
+        panels_text = "\n".join(f"{i+1}. {p}" for i, p in enumerate(panels))
+        return f"""
+Return only JSON, NO thinks, NO comments, NO explanations.
+# Normalized Thumbnail
+{thumbnail}
+
+# Normalized Panels
+{panels_text}
+"""
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        scenario_sec = state.scenario
+        image_sec = state.image
+        config = state.config.config or {}
+        trace_id = meta.trace_id
+
+        # 1) 정규화 호출
+        logger.info(f"[n08a] 정규화 LLM 호출 시작", extra={"trace_id": trace_id})
+        sys_norm = self._build_system_prompt_normalization()
+        user_norm = self._build_user_prompt_normalization(
+            scenario_sec.thumbnail_image_prompt or "",
+            scenario_sec.comic_scenarios or []
+        )
+        resp_norm = await self.llm_service.generate_text(
+            system_prompt_content=sys_norm,
+            prompt=user_norm,
+            temperature=0.3,
+            max_tokens=1500
+        )
+        raw_norm = resp_norm.get("generated_text", "")
+        logger.debug(f"[n08a] 정규화 LLM 응답: {raw_norm}", extra={"trace_id": trace_id})
+        try:
+            norm = extract_json(raw_norm)
+            logger.info(f"[n08a] 정규화 JSON 파싱 성공", extra={"trace_id": trace_id})
+        except Exception as e:
+            logger.error(f"[n08a] 정규화 JSON 파싱 실패: {e}", extra={"trace_id": trace_id})
+            meta.current_stage = "ERROR"
+            meta.error_message = f"n08a normalization JSON error: {e}"
+            return {"image": image_sec.model_dump(), "meta": meta.model_dump()}
+
+        thumbnail_norm = norm.get("thumbnail_prompt", "").strip()
+        panels_norm = norm.get("panels", [])
+        logger.debug(f"[n08a] 정규화 결과 thumbnail: {thumbnail_norm}, panels: {panels_norm}", extra={"trace_id": trace_id})
+
+        # 2) 모드별(Flux/XL) 호출
+        mode = config.get("image_mode", "flux").lower()
+        mode = "xl"   # 테스트용 모드 고정
+        logger.info(f"[n08a] 이미지 모드별 LLM 호출 시작 (mode={mode})", extra={"trace_id": trace_id})
+        if mode == "flux":
+            sys_mode = self._build_system_prompt_flux()
+        else:
+            sys_mode = self._build_system_prompt_xl()
+
+        user_mode = self._build_user_prompt_mode(thumbnail_norm, panels_norm)
+        resp_mode = await self.llm_service.generate_text(
+            system_prompt_content=sys_mode,
+            prompt=user_mode,
+            temperature=0.7,
+            max_tokens=1500
+        )
+        raw_mode = resp_mode.get("generated_text", "")
+        logger.debug(f"[n08a] 모드별 LLM 응답: {raw_mode}", extra={"trace_id": trace_id})
+        try:
+            final = extract_json(raw_mode)
+            logger.info(f"[n08a] 모드별 JSON 파싱 성공", extra={"trace_id": trace_id})
+        except Exception as e:
+            logger.error(f"[n08a] 모드별 JSON 파싱 실패: {e}", extra={"trace_id": trace_id})
+            meta.current_stage = "ERROR"
+            meta.error_message = f"n08a mode-specific JSON error: {e}"
+            return {"image": image_sec.model_dump(), "meta": meta.model_dump()}
+
+        # 3) ImageSection 에 최종 프롬프트 저장
+        entries: List[Dict[str, Any]] = []
+
+        # 썸네일
+        if mode == "flux":
+            thumb_prompt = final.get("thumbnail_prompt", "").strip()
+        else:
+            thumb_prompt = ", ".join(final.get("thumbnail_tokens", []))
+        entries.append({
+            "scene_identifier": "thumbnail",
+            "mode": mode,
+            "prompt_used": thumb_prompt
+        })
+
+        # 각 패널
+        for idx, panel in enumerate(scenario_sec.comic_scenarios or []):
+            scene_id = panel.get("scene_identifier", f"S0{idx+1}")
+            if mode == "flux":
+                panel_prompts = final.get("panel_prompts", [])
+                prompt_text = panel_prompts[idx] if idx < len(panel_prompts) else ""
+            else:
+                tokens_list = final.get("panel_tokens", [])
+                prompt_text = " ".join(tokens_list[idx]) if idx < len(tokens_list) else ""
+            entries.append({
+                "scene_identifier": scene_id,
+                "mode": mode,
+                "prompt_used": prompt_text
+            })
+
+        image_sec.refined_prompts = entries
+        logger.info(f"[n08a] refined_prompts 저장 완료: {len(entries)}개", extra={"trace_id": trace_id})
+        meta.current_stage = "n09_image_generation"
+        return {"image": image_sec.model_dump(), "meta": meta.model_dump()}

--- a/app/nodes_v2/n08a_image_prompt_refine_node.py
+++ b/app/nodes_v2/n08a_image_prompt_refine_node.py
@@ -1,4 +1,4 @@
-# ai/app/nodes/n08a_image_prompt_refinement_node.py
+# ai/app/nodes_v2/n08a_image_prompt_refinement_node.py
 
 import json
 from typing import Dict, Any, List

--- a/app/nodes_v2/n08a_image_prompt_refine_node.py
+++ b/app/nodes_v2/n08a_image_prompt_refine_node.py
@@ -144,7 +144,7 @@ Return only JSON, NO thinks, NO comments, NO explanations.
 
         # 2) 모드별(Flux/XL) 호출
         mode = config.get("image_mode", "flux").lower()
-        mode = "xl"   # 테스트용 모드 고정
+        mode = "flux"   # 모드테스트 고정
         logger.info(f"[n08a] 이미지 모드별 LLM 호출 시작 (mode={mode})", extra={"trace_id": trace_id})
         if mode == "flux":
             sys_mode = self._build_system_prompt_flux()

--- a/app/nodes_v2/n09_image_generation_node.py
+++ b/app/nodes_v2/n09_image_generation_node.py
@@ -1,0 +1,119 @@
+# ai/app/nodes_v2/n09_image_generation_node.py
+
+import asyncio
+import traceback
+from datetime import datetime, timezone
+from typing import Dict, Any, List, Optional
+
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger, summarize_for_logging
+from app.config.settings import Settings
+from app.services.image_service import ImageService
+
+logger = get_logger(__name__)
+settings = Settings()
+
+MAX_PARALLEL_IMAGE_GENERATION = settings.IMAGE_MAX_PARALLEL_TASKS or 1
+
+
+class N09ImageGenerationNode:
+    def __init__(self, image_service: ImageService):
+        self.image_service = image_service
+        logger.info(f"N09 initialized. Max parallel: {MAX_PARALLEL_IMAGE_GENERATION}")
+
+    async def _generate_single_image_entry(
+        self,
+        prompt: str,
+        mode: str,
+        scene_identifier: str,
+        is_thumbnail: bool,
+        image_style_config: Optional[Dict[str, Any]],
+        trace_id: str,
+        extra_log_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        result = {
+            "scene_identifier": scene_identifier,
+            "prompt_used": prompt,
+            "image_path": None,
+            "image_url": None,
+            "is_thumbnail": is_thumbnail,
+            "mode": mode,
+            "error": None,
+            "raw_service_response": None
+        }
+
+        if not prompt:
+            result["error"] = "Prompt is empty"
+            logger.warning(f"[N09] Missing prompt for {scene_identifier}", extra=extra_log_data)
+            return result
+
+        try:
+            generation_params = image_style_config or {}
+            negative_prompt = generation_params.pop("negative_prompt", settings.IMAGE_DEFAULT_NEGATIVE_PROMPT)
+
+            api_response = await self.image_service.generate_image(
+                mode=mode,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                **generation_params
+            )
+            result["raw_service_response"] = api_response
+            if api_response.get("error"):
+                result["error"] = api_response["error"]
+                logger.warning(f"[N09] Image generation failed for {scene_identifier}: {result['error']}",
+                               extra=extra_log_data)
+            else:
+                result["image_path"] = api_response.get("image_path")
+                result["image_url"] = api_response.get("image_url")
+        except Exception as e:
+            result["error"] = str(e)
+            result["raw_service_response"] = {"traceback": traceback.format_exc()}
+            logger.exception(f"[N09] Unexpected error for {scene_identifier}", extra=extra_log_data)
+        return result
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        meta = state.meta
+        image_sec = state.image
+        config = state.config.config or {}
+        trace_id = meta.trace_id
+        comic_id = meta.comic_id
+
+        extra_log = {"trace_id": trace_id, "comic_id": comic_id, "node": "N09"}
+
+        refined_prompts = image_sec.refined_prompts
+        if not refined_prompts:
+            msg = "[N09] No refined prompts found"
+            logger.error(msg, extra=extra_log)
+            meta.current_stage = "ERROR"
+            meta.error_message = msg
+            return {"image": image_sec.model_dump(), "meta": meta.model_dump()}
+
+        tasks = []
+        for entry in refined_prompts:
+            scene_id = entry.get("scene_identifier")
+            prompt = entry.get("prompt_used", "").strip()
+            mode = entry.get("mode", "flux")
+            is_thumbnail = scene_id.lower() == "thumbnail"
+
+            style_config = config.get("image_generation_style", {}).get(
+                scene_id, config.get("image_generation_style", {}).get("default", {})
+            )
+
+            tasks.append(
+                self._generate_single_image_entry(
+                    prompt=prompt,
+                    mode=mode,
+                    scene_identifier=scene_id,
+                    is_thumbnail=is_thumbnail,
+                    image_style_config=style_config,
+                    trace_id=trace_id,
+                    extra_log_data=extra_log
+                )
+            )
+
+        results = await asyncio.gather(*tasks)
+        image_sec.generated_comic_images = results
+        meta.current_stage = "N09_IMAGE_GENERATION_COMPLETED"
+
+        logger.info(f"[N09] Completed image generation: {len(results)} entries", extra=extra_log)
+        return {"image": image_sec.model_dump(), "meta": meta.model_dump()}

--- a/app/nodes_v2/show_state_node.py
+++ b/app/nodes_v2/show_state_node.py
@@ -1,0 +1,14 @@
+# ai/app/nodes_v2/show_state_node.py
+from typing import Dict, Any
+from app.workflows.state_v2 import WorkflowState
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class ShowStateNode:
+    def __init__(self):
+        pass
+
+    async def run(self, state: WorkflowState) -> Dict[str, Any]:
+        logger.debug("🧾 Final state dump:\n%s", state.model_dump_json(indent=2))
+        return state.model_dump()

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -64,6 +64,7 @@ class ImageService:
     # ... (generate_image, close 메소드는 이전 제공 코드와 동일하게 유지) ...
     async def generate_image(
             self,
+            mode: str,
             prompt: str,
             negative_prompt: Optional[str] = None,
             **kwargs  # 추가적인 API 파라미터를 위한 kwargs
@@ -76,7 +77,7 @@ class ImageService:
             self.logger.error("빈 프롬프트가 이미지 생성 서비스에 제공되었습니다.")
             return {"error": "Prompt cannot be empty"}
 
-        payload = {"prompt": prompt, **kwargs}
+        payload = {"mode": mode, "prompt": prompt, **kwargs}
         if negative_prompt:
             payload["negative_prompt"] = negative_prompt
 

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -64,7 +64,7 @@ class ImageService:
     # ... (generate_image, close 메소드는 이전 제공 코드와 동일하게 유지) ...
     async def generate_image(
             self,
-            mode: str,
+            model_name: str,
             prompt: str,
             negative_prompt: Optional[str] = None,
             **kwargs  # 추가적인 API 파라미터를 위한 kwargs
@@ -77,7 +77,7 @@ class ImageService:
             self.logger.error("빈 프롬프트가 이미지 생성 서비스에 제공되었습니다.")
             return {"error": "Prompt cannot be empty"}
 
-        payload = {"mode": mode, "prompt": prompt, **kwargs}
+        payload = {"model_name": model_name, "prompt": prompt, **kwargs}
         if negative_prompt:
             payload["negative_prompt"] = negative_prompt
 

--- a/app/tools/think_parser_tool.py
+++ b/app/tools/think_parser_tool.py
@@ -1,0 +1,50 @@
+import re, json
+
+def extract_json(text: str) -> dict:
+    clean = re.sub(r"</?think>", "", text)
+    m = re.search(r"(\{[\s\S]*\})", clean)
+    return json.loads(m.group(1)) if m else {}
+
+def extract_json_all(text: str) -> list:
+    clean = re.sub(r"</?think>", "", text)
+    m = re.search(r"\[\s*{[\s\S]*?}\s*]", clean)
+    if m:
+        try:
+            data = json.loads(m.group(0))
+            if isinstance(data, list):
+                return [normalize_plan(entry) for entry in data if isinstance(entry, dict)]
+        except json.JSONDecodeError:
+            pass
+    return []
+
+def normalize_plan(plan: dict) -> dict:
+    def flatten(val):
+        # list of list 처리
+        if isinstance(val, list):
+            flattened = []
+            for item in val:
+                if isinstance(item, list):
+                    flattened.extend(item)
+                else:
+                    flattened.append(item)
+            return flattened
+        return val
+
+    plan["max_results"] = plan.get("max_results", 5)
+    if isinstance(plan["max_results"], list):
+        plan["max_results"] = plan["max_results"][0] if plan["max_results"] else 5
+    if not isinstance(plan["max_results"], int):
+        try:
+            plan["max_results"] = int(plan["max_results"])
+        except Exception:
+            plan["max_results"] = 5
+
+    plan["queries"] = flatten(plan.get("queries", []))
+    if not isinstance(plan["queries"], list):
+        plan["queries"] = [plan["queries"]] if plan["queries"] else []
+
+    plan["domains"] = flatten(plan.get("domains", []))
+    if not isinstance(plan["domains"], list):
+        plan["domains"] = [plan["domains"]] if plan["domains"] else []
+
+    return plan

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -21,9 +21,9 @@ from app.nodes_v2.n04_execute_search_node import N04ExecuteSearchNode
 from app.nodes_v2.n05_report_generation_node import N05ReportGenerationNode
 # from app.nodes.n05_hitl_review_node import N05HITLReviewNode  # HITL 노드 추가
 from app.nodes_v2.n06_save_report_node import N06SaveReportNode
-# from app.nodes.n06a_contextual_summary_node import N06AContextualSummaryNode
-# from app.nodes.n07_comic_ideation_node import N07ComicIdeationNode
-# from app.nodes.n08_scenario_generation_node import N08ScenarioGenerationNode
+from app.nodes_v2.n06b_contextual_summary_node import N06BContextualSummaryNode
+from app.nodes_v2.n07_comic_ideation_node import N07ComicIdeationNode
+from app.nodes_v2.n08_scenario_generation_node import N08ScenarioGenerationNode
 # from app.nodes.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
 # from app.nodes.n10_finalize_and_notify_node import N10FinalizeAndNotifyNode # <<< N10 임포트
 
@@ -63,9 +63,9 @@ async def compile_workflow(
     n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
     # n05_hitl_review = N05HITLReviewNode(llm_service=llm_service)  # LLM 서비스 주입
     n06_save_report = N06SaveReportNode()
-    # n06a_contextual_summary = N06AContextualSummaryNode(llm_service=llm_service)
-    # n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
-    # n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
+    n06b_contextual_summary = N06BContextualSummaryNode(llm_service=llm_service)
+    n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
+    n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
     # n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
     # n10_finalize_and_notify = N10FinalizeAndNotifyNode(
     #     storage_service=storage_service,
@@ -79,9 +79,9 @@ async def compile_workflow(
     workflow.add_node("n05_report_generation", n05_report_generation.run)
     # workflow.add_node("n05_hitl_review", n05_hitl_review.run)  # HITL 노드 추가
     workflow.add_node("n06_save_report", n06_save_report.run)
-    # workflow.add_node("n06a_contextual_summary", n06a_contextual_summary.run)
-    # workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
-    # workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
+    workflow.add_node("n06b_contextual_summary", n06b_contextual_summary.run)
+    workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
+    workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
     # workflow.add_node("n09_image_generation", n09_image_generation.run) # <<< N09 노드 추가
     # workflow.add_node("n10_finalize_and_notify", n10_finalize_and_notify.run)  # <<< N10 노드 추가
 
@@ -111,10 +111,10 @@ async def compile_workflow(
 
     # # HITL 이후 노드들
     workflow.add_edge("n05_report_generation", "n06_save_report")
-    workflow.add_edge("n06_save_report", END)
-    # workflow.add_edge("n06_save_report", "n06a_contextual_summary")
-    # workflow.add_edge("n06a_contextual_summary", "n07_comic_ideation")
-    # workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
+    workflow.add_edge("n06_save_report", "n06b_contextual_summary")
+    workflow.add_edge("n06b_contextual_summary", "n07_comic_ideation")
+    workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
+    workflow.add_edge("n08_scenario_generation", END)
     # workflow.add_edge("n08_scenario_generation", "n09_image_generation")
     # workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")
     # workflow.add_edge("n10_finalize_and_notify", END)

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -25,7 +25,7 @@ from app.nodes_v2.n06b_contextual_summary_node import N06BContextualSummaryNode
 from app.nodes_v2.n07_comic_ideation_node import N07ComicIdeationNode
 from app.nodes_v2.n08_scenario_generation_node import N08ScenarioGenerationNode
 from app.nodes_v2.n08a_image_prompt_refine_node import N08aImagePromptRefinementNode
-# from app.nodes.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
+from app.nodes_v2.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
 # from app.nodes.n10_finalize_and_notify_node import N10FinalizeAndNotifyNode # <<< N10 임포트
 
 from app.services.storage_service import StorageService # <<< StorageService 임포트
@@ -68,7 +68,7 @@ async def compile_workflow(
     n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
     n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
     n08a_image_prompt_refine = N08aImagePromptRefinementNode(llm_service=llm_service)
-    # n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
+    n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
     # n10_finalize_and_notify = N10FinalizeAndNotifyNode(
     #     storage_service=storage_service,
     #     http_session=external_api_session  # 공유 세션 전달 또는 None
@@ -85,7 +85,7 @@ async def compile_workflow(
     workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
     workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
     workflow.add_node("n08a_image_prompt_refine", n08a_image_prompt_refine.run)
-    # workflow.add_node("n09_image_generation", n09_image_generation.run) # <<< N09 노드 추가
+    workflow.add_node("n09_image_generation", n09_image_generation.run)
     # workflow.add_node("n10_finalize_and_notify", n10_finalize_and_notify.run)  # <<< N10 노드 추가
 
     # --- 엣지 정의 (Node 1 -> ... -> 8 -> 9 -> END) ---
@@ -118,12 +118,12 @@ async def compile_workflow(
     workflow.add_edge("n06b_contextual_summary", "n07_comic_ideation")
     workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
     workflow.add_edge("n08_scenario_generation", "n08a_image_prompt_refine")
+    workflow.add_edge("n08a_image_prompt_refine", "n09_image_generation")
 
     from app.nodes_v2.show_state_node import ShowStateNode
     workflow.add_node("show_state", ShowStateNode().run)
-    workflow.add_edge("n08a_image_prompt_refine", "show_state")
+    workflow.add_edge("n09_image_generation", "show_state")
     workflow.add_edge("show_state", END)
-    # workflow.add_edge("n08_scenario_generation", "n09_image_generation")
     # workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")
     # workflow.add_edge("n10_finalize_and_notify", END)
 

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -18,9 +18,9 @@ from app.nodes_v2.n01_initialize_node import N01InitializeNode
 from app.nodes_v2.n02_analyze_query_node import N02AnalyzeQueryNode
 from app.nodes_v2.n03_understand_and_plan_node import N03UnderstandAndPlanNode
 from app.nodes_v2.n04_execute_search_node import N04ExecuteSearchNode
-# from app.nodes.n05_report_generation_node import N05ReportGenerationNode
+from app.nodes_v2.n05_report_generation_node import N05ReportGenerationNode
 # from app.nodes.n05_hitl_review_node import N05HITLReviewNode  # HITL 노드 추가
-# from app.nodes.n06_save_report_node import N06SaveReportNode
+from app.nodes_v2.n06_save_report_node import N06SaveReportNode
 # from app.nodes.n06a_contextual_summary_node import N06AContextualSummaryNode
 # from app.nodes.n07_comic_ideation_node import N07ComicIdeationNode
 # from app.nodes.n08_scenario_generation_node import N08ScenarioGenerationNode
@@ -60,9 +60,9 @@ async def compile_workflow(
     n02_analyze_query = N02AnalyzeQueryNode(llm_service=llm_service)
     n03_understand_and_plan = N03UnderstandAndPlanNode(llm_service=llm_service)
     n04_execute_search = N04ExecuteSearchNode(search_tool=Google_Search_tool)
-    # n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
+    n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
     # n05_hitl_review = N05HITLReviewNode(llm_service=llm_service)  # LLM 서비스 주입
-    # n06_save_report = N06SaveReportNode()
+    n06_save_report = N06SaveReportNode()
     # n06a_contextual_summary = N06AContextualSummaryNode(llm_service=llm_service)
     # n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
     # n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
@@ -76,9 +76,9 @@ async def compile_workflow(
     workflow.add_node("n02_analyze_query", n02_analyze_query.run)
     workflow.add_node("n03_understand_and_plan", n03_understand_and_plan.run)
     workflow.add_node("n04_execute_search", n04_execute_search.run)
-    # workflow.add_node("n05_report_generation", n05_report_generation.run)
+    workflow.add_node("n05_report_generation", n05_report_generation.run)
     # workflow.add_node("n05_hitl_review", n05_hitl_review.run)  # HITL 노드 추가
-    # workflow.add_node("n06_save_report", n06_save_report.run)
+    workflow.add_node("n06_save_report", n06_save_report.run)
     # workflow.add_node("n06a_contextual_summary", n06a_contextual_summary.run)
     # workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
     # workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
@@ -90,8 +90,7 @@ async def compile_workflow(
     workflow.add_edge("n01_initialize", "n02_analyze_query")
     workflow.add_edge("n02_analyze_query", "n03_understand_and_plan")
     workflow.add_edge("n03_understand_and_plan", "n04_execute_search")
-    workflow.add_edge("n04_execute_search", END)
-    # workflow.add_edge("n04_execute_search", "n05_report_generation")
+    workflow.add_edge("n04_execute_search", "n05_report_generation")
     # workflow.add_edge("n05_report_generation", "n05_hitl_review")
 
     # # HITL 노드의 결과에 따른 분기 추가 (Section 구조에 맞게 state.meta.workflow_status 사용)
@@ -111,6 +110,8 @@ async def compile_workflow(
     # )
 
     # # HITL 이후 노드들
+    workflow.add_edge("n05_report_generation", "n06_save_report")
+    workflow.add_edge("n06_save_report", END)
     # workflow.add_edge("n06_save_report", "n06a_contextual_summary")
     # workflow.add_edge("n06a_contextual_summary", "n07_comic_ideation")
     # workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -114,7 +114,11 @@ async def compile_workflow(
     workflow.add_edge("n06_save_report", "n06b_contextual_summary")
     workflow.add_edge("n06b_contextual_summary", "n07_comic_ideation")
     workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
-    workflow.add_edge("n08_scenario_generation", END)
+
+    from app.nodes_v2.show_state_node import ShowStateNode
+    workflow.add_node("show_state", ShowStateNode().run)
+    workflow.add_edge("n08_scenario_generation", "show_state")
+    workflow.add_edge("show_state", END)
     # workflow.add_edge("n08_scenario_generation", "n09_image_generation")
     # workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")
     # workflow.add_edge("n10_finalize_and_notify", END)

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -24,6 +24,7 @@ from app.nodes_v2.n06_save_report_node import N06SaveReportNode
 from app.nodes_v2.n06b_contextual_summary_node import N06BContextualSummaryNode
 from app.nodes_v2.n07_comic_ideation_node import N07ComicIdeationNode
 from app.nodes_v2.n08_scenario_generation_node import N08ScenarioGenerationNode
+from app.nodes_v2.n08a_image_prompt_refine_node import N08aImagePromptRefinementNode
 # from app.nodes.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
 # from app.nodes.n10_finalize_and_notify_node import N10FinalizeAndNotifyNode # <<< N10 임포트
 
@@ -66,6 +67,7 @@ async def compile_workflow(
     n06b_contextual_summary = N06BContextualSummaryNode(llm_service=llm_service)
     n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
     n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
+    n08a_image_prompt_refine = N08aImagePromptRefinementNode(llm_service=llm_service)
     # n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
     # n10_finalize_and_notify = N10FinalizeAndNotifyNode(
     #     storage_service=storage_service,
@@ -82,6 +84,7 @@ async def compile_workflow(
     workflow.add_node("n06b_contextual_summary", n06b_contextual_summary.run)
     workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
     workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
+    workflow.add_node("n08a_image_prompt_refine", n08a_image_prompt_refine.run)
     # workflow.add_node("n09_image_generation", n09_image_generation.run) # <<< N09 노드 추가
     # workflow.add_node("n10_finalize_and_notify", n10_finalize_and_notify.run)  # <<< N10 노드 추가
 
@@ -114,10 +117,11 @@ async def compile_workflow(
     workflow.add_edge("n06_save_report", "n06b_contextual_summary")
     workflow.add_edge("n06b_contextual_summary", "n07_comic_ideation")
     workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
+    workflow.add_edge("n08_scenario_generation", "n08a_image_prompt_refine")
 
     from app.nodes_v2.show_state_node import ShowStateNode
     workflow.add_node("show_state", ShowStateNode().run)
-    workflow.add_edge("n08_scenario_generation", "show_state")
+    workflow.add_edge("n08a_image_prompt_refine", "show_state")
     workflow.add_edge("show_state", END)
     # workflow.add_edge("n08_scenario_generation", "n09_image_generation")
     # workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")

--- a/app/workflows/main_workflow.py
+++ b/app/workflows/main_workflow.py
@@ -14,21 +14,22 @@ from app.tools.search.Google_Search_tool import GoogleSearchTool
 from app.services.image_service import ImageService # <<< 이미지 서비스 임포트
 
 # --- 노드 클래스 임포트 (N01 ~ N09) ---
-from app.nodes.n01_initialize_node import N01InitializeNode
-from app.nodes.n02_analyze_query_node import N02AnalyzeQueryNode
-from app.nodes.n03_understand_and_plan_node import N03UnderstandAndPlanNode
-from app.nodes.n04_execute_search_node import N04ExecuteSearchNode
-from app.nodes.n05_report_generation_node import N05ReportGenerationNode
-from app.nodes.n05_hitl_review_node import N05HITLReviewNode  # HITL 노드 추가
-from app.nodes.n06_save_report_node import N06SaveReportNode
-from app.nodes.n06a_contextual_summary_node import N06AContextualSummaryNode
-from app.nodes.n07_comic_ideation_node import N07ComicIdeationNode
-from app.nodes.n08_scenario_generation_node import N08ScenarioGenerationNode
-from app.nodes.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
+from app.nodes_v2.n01_initialize_node import N01InitializeNode
+from app.nodes_v2.n02_analyze_query_node import N02AnalyzeQueryNode
+from app.nodes_v2.n03_understand_and_plan_node import N03UnderstandAndPlanNode
+from app.nodes_v2.n04_execute_search_node import N04ExecuteSearchNode
+# from app.nodes.n05_report_generation_node import N05ReportGenerationNode
+# from app.nodes.n05_hitl_review_node import N05HITLReviewNode  # HITL 노드 추가
+# from app.nodes.n06_save_report_node import N06SaveReportNode
+# from app.nodes.n06a_contextual_summary_node import N06AContextualSummaryNode
+# from app.nodes.n07_comic_ideation_node import N07ComicIdeationNode
+# from app.nodes.n08_scenario_generation_node import N08ScenarioGenerationNode
+# from app.nodes.n09_image_generation_node import N09ImageGenerationNode # <<< N09 임포트
+# from app.nodes.n10_finalize_and_notify_node import N10FinalizeAndNotifyNode # <<< N10 임포트
 
 from app.services.storage_service import StorageService # <<< StorageService 임포트
 from app.services.translation_service import TranslationService # <<< TranslationService 임포트
-from app.nodes.n10_finalize_and_notify_node import N10FinalizeAndNotifyNode # <<< N10 임포트
+
 
 
 logger = get_logger(__name__)
@@ -56,65 +57,66 @@ async def compile_workflow(
 
     # --- 노드 인스턴스 생성 (N01 ~ N09) ---
     n01_initialize = N01InitializeNode()
-    n02_analyze_query = N02AnalyzeQueryNode(llm_service=llm_service, search_tool=Google_Search_tool)
+    n02_analyze_query = N02AnalyzeQueryNode(llm_service=llm_service)
     n03_understand_and_plan = N03UnderstandAndPlanNode(llm_service=llm_service)
     n04_execute_search = N04ExecuteSearchNode(search_tool=Google_Search_tool)
-    n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
-    n05_hitl_review = N05HITLReviewNode(llm_service=llm_service)  # LLM 서비스 주입
-    n06_save_report = N06SaveReportNode()
-    n06a_contextual_summary = N06AContextualSummaryNode(llm_service=llm_service)
-    n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
-    n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
-    n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
-    n10_finalize_and_notify = N10FinalizeAndNotifyNode(
-        storage_service=storage_service,
-        http_session=external_api_session  # 공유 세션 전달 또는 None
-    )
+    # n05_report_generation = N05ReportGenerationNode(llm_service=llm_service)
+    # n05_hitl_review = N05HITLReviewNode(llm_service=llm_service)  # LLM 서비스 주입
+    # n06_save_report = N06SaveReportNode()
+    # n06a_contextual_summary = N06AContextualSummaryNode(llm_service=llm_service)
+    # n07_comic_ideation = N07ComicIdeationNode(llm_service=llm_service)
+    # n08_scenario_generation = N08ScenarioGenerationNode(llm_service=llm_service)
+    # n09_image_generation = N09ImageGenerationNode(image_service=image_generation_service)
+    # n10_finalize_and_notify = N10FinalizeAndNotifyNode(
+    #     storage_service=storage_service,
+    #     http_session=external_api_session  # 공유 세션 전달 또는 None
+    # )
     # --- 노드 추가 (Node 1 ~ 9) ---
     workflow.add_node("n01_initialize", n01_initialize.run)
     workflow.add_node("n02_analyze_query", n02_analyze_query.run)
     workflow.add_node("n03_understand_and_plan", n03_understand_and_plan.run)
     workflow.add_node("n04_execute_search", n04_execute_search.run)
-    workflow.add_node("n05_report_generation", n05_report_generation.run)
-    workflow.add_node("n05_hitl_review", n05_hitl_review.run)  # HITL 노드 추가
-    workflow.add_node("n06_save_report", n06_save_report.run)
-    workflow.add_node("n06a_contextual_summary", n06a_contextual_summary.run)
-    workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
-    workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
-    workflow.add_node("n09_image_generation", n09_image_generation.run) # <<< N09 노드 추가
-    workflow.add_node("n10_finalize_and_notify", n10_finalize_and_notify.run)  # <<< N10 노드 추가
+    # workflow.add_node("n05_report_generation", n05_report_generation.run)
+    # workflow.add_node("n05_hitl_review", n05_hitl_review.run)  # HITL 노드 추가
+    # workflow.add_node("n06_save_report", n06_save_report.run)
+    # workflow.add_node("n06a_contextual_summary", n06a_contextual_summary.run)
+    # workflow.add_node("n07_comic_ideation", n07_comic_ideation.run)
+    # workflow.add_node("n08_scenario_generation", n08_scenario_generation.run)
+    # workflow.add_node("n09_image_generation", n09_image_generation.run) # <<< N09 노드 추가
+    # workflow.add_node("n10_finalize_and_notify", n10_finalize_and_notify.run)  # <<< N10 노드 추가
 
     # --- 엣지 정의 (Node 1 -> ... -> 8 -> 9 -> END) ---
     workflow.set_entry_point("n01_initialize")
     workflow.add_edge("n01_initialize", "n02_analyze_query")
     workflow.add_edge("n02_analyze_query", "n03_understand_and_plan")
     workflow.add_edge("n03_understand_and_plan", "n04_execute_search")
-    workflow.add_edge("n04_execute_search", "n05_report_generation")
-    workflow.add_edge("n05_report_generation", "n05_hitl_review")
+    workflow.add_edge("n04_execute_search", END)
+    # workflow.add_edge("n04_execute_search", "n05_report_generation")
+    # workflow.add_edge("n05_report_generation", "n05_hitl_review")
 
-    # HITL 노드의 결과에 따른 분기 추가 (Section 구조에 맞게 state.meta.workflow_status 사용)
-    def should_continue(state: WorkflowState) -> bool:
-        """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정 (Section 구조 사용)"""
-        # state.meta.workflow_status가 'intentionally_terminated'이면 종료, 아니면 계속
-        return getattr(state.meta, "workflow_status", None) != "intentionally_terminated"
+    # # HITL 노드의 결과에 따른 분기 추가 (Section 구조에 맞게 state.meta.workflow_status 사용)
+    # def should_continue(state: WorkflowState) -> bool:
+    #     """HITL 노드의 결과를 확인하여 워크플로우 계속 진행 여부를 결정 (Section 구조 사용)"""
+    #     # state.meta.workflow_status가 'intentionally_terminated'이면 종료, 아니면 계속
+    #     return getattr(state.meta, "workflow_status", None) != "intentionally_terminated"
 
-    # HITL 노드에서 조건부 분기 추가
-    workflow.add_conditional_edges(
-        "n05_hitl_review",
-        should_continue,
-        {
-            True: "n06_save_report",  # 계속 진행
-            False: END  # 의도적 종료
-        }
-    )
+    # # HITL 노드에서 조건부 분기 추가
+    # workflow.add_conditional_edges(
+    #     "n05_hitl_review",
+    #     should_continue,
+    #     {
+    #         True: "n06_save_report",  # 계속 진행
+    #         False: END  # 의도적 종료
+    #     }
+    # )
 
-    # HITL 이후 노드들
-    workflow.add_edge("n06_save_report", "n06a_contextual_summary")
-    workflow.add_edge("n06a_contextual_summary", "n07_comic_ideation")
-    workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
-    workflow.add_edge("n08_scenario_generation", "n09_image_generation")
-    workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")
-    workflow.add_edge("n10_finalize_and_notify", END)
+    # # HITL 이후 노드들
+    # workflow.add_edge("n06_save_report", "n06a_contextual_summary")
+    # workflow.add_edge("n06a_contextual_summary", "n07_comic_ideation")
+    # workflow.add_edge("n07_comic_ideation", "n08_scenario_generation")
+    # workflow.add_edge("n08_scenario_generation", "n09_image_generation")
+    # workflow.add_edge("n09_image_generation", "n10_finalize_and_notify")
+    # workflow.add_edge("n10_finalize_and_notify", END)
 
     # --- 워크플로우 컴파일 ---
     compiled_app = workflow.compile()

--- a/app/workflows/state_v2.py
+++ b/app/workflows/state_v2.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 
 
+# === 이미지 프롬프트 모드 base 리스트 ===
+DEFAULT_IMAGE_MODE = "ghibli-flux"
+FLUX_BASE_MODES = ["ghibli-flux"]
+XL_BASE_MODES = ["anything-xl"]
+
 #  Raw / large TypedDict types
 class RawArticle(TypedDict):
     url: str

--- a/app/workflows/state_v2.py
+++ b/app/workflows/state_v2.py
@@ -64,6 +64,7 @@ class ScenarioSection(BaseModel):
 
 
 class ImageSection(BaseModel):
+    refined_prompts: List[Dict[str, Any]] = Field(default_factory=list) # 썸네일, 패널 프롬프트 모두 저장
     generated_comic_images: List[Dict[str, Any]] = Field(default_factory=list)
 
 

--- a/image_model_tunneling.ipynb
+++ b/image_model_tunneling.ipynb
@@ -1,32 +1,33 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "machine_shape": "hm",
-      "gpuType": "A100"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "BPe9QPfqlgwD"
+      },
+      "outputs": [],
+      "source": [
+        "import time\n",
+        "g_start = time.time()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "cellView": "form",
+        "id": "w-k2065nuVgM"
+      },
+      "outputs": [],
       "source": [
         "%%capture\n",
         "# @title 1. 라이브러리 설치\n",
         "%pip install -q fastapi uvicorn[standard]\n",
-        "%pip install -q pyngrok>=7.0.0 diffusers>=0.27.0 transformers accelerate\n",
-        "%pip install -q controlnet_aux torch>=2.0.0 Pillow\n",
+        "%pip install -q pyngrok>=7.0.0 # diffusers>=0.27.0 transformers accelerate\n",
+        "%pip install -q controlnet_aux Pillow # torch>=2.0.0\n",
         "%pip install -q safetensors pydantic huggingface_hub python-multipart\n",
-        "%pip install -U diffusers transformers accelerate safetensors\n",
+        "# %pip install -U diffusers transformers accelerate safetensors\n",
         "%pip install -q wget\n",
         "# %pip install -q peft requests\n",
         "\n",
@@ -41,28 +42,18 @@
         "# # %pip install -q peft requests\n",
         "\n",
         "print(\"✅ 라이브러리 설치 완료\")"
-      ],
-      "metadata": {
-        "id": "w-k2065nuVgM"
-      },
-      "execution_count": 1,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# 라이브러리 호환성 확인\n",
-        "# jedi는 상관 없음 (colab 특성 상, 설치 안한다고 함)\n",
-        "!pip check"
-      ],
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "7AY8e66XRJzV",
-        "outputId": "29f52035-31de-4a4b-da6b-e512f94473ba"
+        "outputId": "43ef0033-28fc-4ab8-c0c4-dc7e03678f9e"
       },
-      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
@@ -71,37 +62,34 @@
             "ipython 7.34.0 requires jedi, which is not installed.\n"
           ]
         }
+      ],
+      "source": [
+        "# 라이브러리 호환성 확인\n",
+        "# jedi는 상관 없음 (colab 특성 상, 설치 안한다고 함)\n",
+        "!pip check"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# @title InstantX 코드 파일 다운로드\n",
-        "import wget\n",
-        "import os\n",
-        "\n",
-        "# Flux InstantX 파일 리스트\n",
-        "files = [\n",
-        "    (\"pipeline_flux_ipa.py\", \"https://huggingface.co/InstantX/FLUX.1-dev-IP-Adapter/resolve/main/pipeline_flux_ipa.py?download=true\"),\n",
-        "    (\"transformer_flux.py\", \"https://huggingface.co/InstantX/FLUX.1-dev-IP-Adapter/resolve/main/transformer_flux.py?download=true\"),\n",
-        "    (\"attention_processor.py\", \"https://huggingface.co/InstantX/FLUX.1-dev-IP-Adapter/resolve/main/attention_processor.py?download=true\"),\n",
-        "    (\"infer_flux_ipa_siglip.py\", \"https://huggingface.co/InstantX/FLUX.1-dev-IP-Adapter/resolve/main/infer_flux_ipa_siglip.py?download=true\"),\n",
-        "    (\"ip-adapter.bin\", \"https://huggingface.co/InstantX/FLUX.1-dev-IP-Adapter/resolve/main/ip-adapter.bin?download=true\"),\n",
-        "]\n",
-        "\n",
-        "for filename, url in files:\n",
-        "    if not os.path.exists(filename):\n",
-        "        wget.download(url, out=filename)\n"
-      ],
+      "execution_count": 4,
       "metadata": {
         "cellView": "form",
-        "id": "_ntweVQSd75c"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "A0jI1SIruVeF",
+        "outputId": "e751afaa-f7f2-4c5b-de02-469cea995a5e"
       },
-      "execution_count": 3,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "🔑 Hugging Face 로그인 중...\n",
+            "✅ Ngrok Authtoken 설정 완료\n"
+          ]
+        }
+      ],
       "source": [
         "# @title 2. Hugging Face 로그인 / Ngrok 설정 (Authtoken 시크릿 키)\n",
         "import os\n",
@@ -111,9 +99,12 @@
         "\n",
         "# Hugging Face 및 ngrok 토큰 (Colab Secret에서 가져오기)\n",
         "hf_token = userdata.get(\"HF_TOKEN\")        # Hugging Face Token\n",
+        "civitai_token = userdata.get(\"CIVITAI_TOKEN\")   # CivitAI Token\n",
         "ngrok_token = userdata.get(\"google_ngrok_authtoken\")  # ngrok Token\n",
         "\n",
         "if hf_token == None:\n",
+        "  print('x')\n",
+        "if civitai_token == None:\n",
         "  print('x')\n",
         "if ngrok_token == None:\n",
         "  print('x')\n",
@@ -128,31 +119,135 @@
         "# ngrok 설정\n",
         "ngrok.set_auth_token(ngrok_token)\n",
         "print(\"✅ Ngrok Authtoken 설정 완료\")"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
       "metadata": {
-        "id": "A0jI1SIruVeF",
+        "cellView": "form",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "cellView": "form",
-        "outputId": "8fc0206a-f912-4aeb-feb1-5df16aca9e88"
+        "id": "2R0izjLyvHfL",
+        "outputId": "8b1ee9e4-a393-46e6-c71c-5c2e64392d26"
       },
-      "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "🔑 Hugging Face 로그인 중...\n",
-            "✅ Ngrok Authtoken 설정 완료\n"
+            "--2025-05-27 07:59:43--  https://civitai.com/api/download/models/1215918?type=Model&format=SafeTensor&size=full&token=2ab1653b9d579f186d295f4540908157\n",
+            "Resolving civitai.com (civitai.com)... 172.67.12.143, 104.22.19.237, 104.22.18.237, ...\n",
+            "Connecting to civitai.com (civitai.com)|172.67.12.143|:443... connected.\n",
+            "HTTP request sent, awaiting response... 307 Temporary Redirect\n",
+            "Location: https://civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com/model/686417/jGhibliV2FluxUltimate.FZyi.safetensors?X-Amz-Expires=86400&response-content-disposition=attachment%3B%20filename%3D%22IllustrationJuanerGhibli_v20.safetensors%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=e01358d793ad6966166af8b3064953ad/20250527/us-east-1/s3/aws4_request&X-Amz-Date=20250527T075943Z&X-Amz-SignedHeaders=host&X-Amz-Signature=25b9f1b92a6ee9c35a0a1b75d6c6e6212a2f6d39ee80f8b967bf28d3df17658d [following]\n",
+            "--2025-05-27 07:59:44--  https://civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com/model/686417/jGhibliV2FluxUltimate.FZyi.safetensors?X-Amz-Expires=86400&response-content-disposition=attachment%3B%20filename%3D%22IllustrationJuanerGhibli_v20.safetensors%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=e01358d793ad6966166af8b3064953ad/20250527/us-east-1/s3/aws4_request&X-Amz-Date=20250527T075943Z&X-Amz-SignedHeaders=host&X-Amz-Signature=25b9f1b92a6ee9c35a0a1b75d6c6e6212a2f6d39ee80f8b967bf28d3df17658d\n",
+            "Resolving civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com (civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com)... 162.159.141.50, 172.66.1.46, 2606:4700:7::12e, ...\n",
+            "Connecting to civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com (civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com)|162.159.141.50|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 11901497256 (11G)\n",
+            "Saving to: ‘illustration_juaner_flux.safetensors’\n",
+            "\n",
+            "illustration_juaner 100%[===================>]  11.08G  34.3MB/s    in 3m 14s  \n",
+            "\n",
+            "2025-05-27 08:02:58 (58.4 MB/s) - ‘illustration_juaner_flux.safetensors’ saved [11901497256/11901497256]\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "# @title 3. CivitAI Checkpoint 다운로드\n",
+        "import os\n",
+        "os.environ[\"CIVITAI_API_TOKEN\"] = civitai_token\n",
+        "\n",
+        "import wget\n",
+        "!wget -O illustration_juaner_flux.safetensors \\\n",
+        "\"https://civitai.com/api/download/models/1215918?type=Model&format=SafeTensor&size=full&token=$CIVITAI_API_TOKEN\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @title 4. Model Pipeline 정의 - model_loader.py\n",
+        "# 이 셀은 Model Pipeline을 생성하는 코드를 model_loader.py 파일로 저장합니다.\n",
+        "\n",
+        "%%writefile model_loader.py\n",
+        "from diffusers import FluxPipeline, DiffusionPipeline, FluxTransformer2DModel\n",
+        "from transformers import T5EncoderModel\n",
+        "\n",
+        "# Ghibli (Flux)\n",
+        "def load_ghibli_flux_model(dtype):\n",
+        "    BASE_MODEL_ID = \"black-forest-labs/FLUX.1-dev\"\n",
+        "    CHECKPOINT_MODEL_ID = \"illustration_juaner_flux.safetensors\"\n",
+        "\n",
+        "    transformer = FluxTransformer2DModel.from_single_file(\n",
+        "        CHECKPOINT_MODEL_ID, torch_dtype=dtype\n",
+        "    )\n",
+        "    text_encoder_2 = T5EncoderModel.from_pretrained(\n",
+        "        BASE_MODEL_ID, subfolder=\"text_encoder_2\", torch_dtype=dtype\n",
+        "    )\n",
+        "    pipe = FluxPipeline.from_pretrained(\n",
+        "        BASE_MODEL_ID,\n",
+        "        transformer=transformer,\n",
+        "        text_encoder_2=text_encoder_2,\n",
+        "        torch_dtype=dtype,\n",
+        "    )\n",
+        "    pipe.enable_model_cpu_offload()\n",
+        "    pipe.enable_attention_slicing()\n",
+        "    return pipe\n",
+        "\n",
+        "# AnythingXL (stable-diffusion-xl style)\n",
+        "def load_anything_xl_model(dtype):\n",
+        "    MODEL_ID = \"stabilityai/stable-diffusion-xl-base-1.0\"\n",
+        "    pipe = DiffusionPipeline.from_pretrained(\n",
+        "        MODEL_ID,\n",
+        "        torch_dtype=dtype,\n",
+        "        variant=\"fp16\"\n",
+        "    )\n",
+        "    pipe.enable_model_cpu_offload()\n",
+        "    pipe.enable_attention_slicing()\n",
+        "    return pipe\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "EWf3DH_gKQcO",
+        "outputId": "d6776f76-eb8e-42e7-cf7d-c8667823fc39"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Writing model_loader.py\n"
           ]
         }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XXvUlWb9HRcD",
+        "outputId": "70905741-5568-4ceb-b86c-870f24da26b3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Writing main_server.py\n"
+          ]
+        }
+      ],
       "source": [
-        "# @title 3. FastAPI 애플리케이션 코드 작성 (main_server.py 파일 생성)\n",
+        "# @title 5. FastAPI 서버 - main_server.py\n",
         "# 이 셀은 FastAPI 서버 코드를 main_server.py 파일로 저장합니다.\n",
         "\n",
         "%%writefile main_server.py\n",
@@ -162,42 +257,23 @@
         "\n",
         "import torch\n",
         "import uvicorn\n",
-        "from fastapi import FastAPI, HTTPException, UploadFile, File, Form\n",
+        "from fastapi import FastAPI, HTTPException\n",
         "from fastapi.responses import Response\n",
         "from pydantic import BaseModel\n",
         "from PIL import Image\n",
         "from pyngrok import ngrok\n",
         "\n",
-        "# Flux 관련 import\n",
-        "from diffusers import FluxPipeline, FluxControlNetModel, FluxControlNetPipeline\n",
-        "from controlnet_aux import CannyDetector\n",
-        "from pipeline_flux_ipa import FluxPipeline as FluxPipelineIP\n",
-        "from transformer_flux import FluxTransformer2DModel\n",
-        "from infer_flux_ipa_siglip import resize_img, IPAdapter\n",
+        "\n",
+        "# --- GPU 설정 ---\n",
+        "device: str = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+        "dtype: torch.dtype = torch.bfloat16 if (device == \"cuda\" and torch.cuda.is_bf16_supported()) else torch.float16\n",
         "\n",
         "# --- 설정 상수 ---\n",
-        "BASE_MODEL_ID = \"black-forest-labs/FLUX.1-dev\"\n",
-        "CONTROLNET_MODEL_ID = \"Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0\"\n",
-        "IMAGE_ENCODER_PATH = \"google/siglip-so400m-patch14-384\"\n",
-        "IPADAPTER_PATH = \"./ip-adapter.bin\"\n",
-        "\n",
         "DEFAULT_STEPS = 30\n",
         "DEFAULT_GUIDANCE_SCALE = 3.5\n",
-        "DEFAULT_CONTROLNET_SCALE = 0.7\n",
-        "DEFAULT_IPADAPTER_SCALE = 0.7\n",
         "IMAGE_WIDTH = 1024\n",
         "IMAGE_HEIGHT = 1024\n",
         "PORT = 8000\n",
-        "\n",
-        "# --- 전역 상태 ---\n",
-        "base_pipe: Optional[FluxPipeline] = None\n",
-        "controlnet_pipe: Optional[FluxControlNetPipeline] = None\n",
-        "pipe_ip: Optional[FluxPipelineIP] = None\n",
-        "ip_model: Optional[IPAdapter] = None\n",
-        "controlnet_preprocessor: Optional[Any] = None\n",
-        "\n",
-        "device: str = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
-        "dtype: torch.dtype = torch.bfloat16 if (device == \"cuda\" and torch.cuda.is_bf16_supported()) else torch.float16\n",
         "\n",
         "# --- 로깅 설정 ---\n",
         "logging.basicConfig(level=logging.INFO)\n",
@@ -219,52 +295,25 @@
         "    logger.info(f\"Using seed: {seed}\")\n",
         "    return torch.Generator(device=\"cuda\").manual_seed(seed)\n",
         "\n",
-        "async def prepare_reference_image(uploaded_image: UploadFile) -> Image.Image:\n",
-        "    image = load_pil_image(await uploaded_image.read())\n",
-        "    return resize_img(image)\n",
+        "# -------------------------- 모델 세팅 관련 --------------------------\n",
+        "# 모델 로딩 모듈 import\n",
+        "from model_loader import load_ghibli_flux_model, load_anything_xl_model\n",
         "\n",
-        "def prepare_control_image(uploaded_image: UploadFile) -> Image.Image:\n",
-        "    if controlnet_preprocessor is None:\n",
-        "        raise RuntimeError(\"ControlNet preprocessor not loaded.\")\n",
-        "    image = load_pil_image(uploaded_image.file.read())\n",
-        "    return controlnet_preprocessor(image)\n",
+        "# --- 전역 pipe 세팅 ---\n",
+        "ghibli_flux_pipe: Optional[Any] = None\n",
+        "anything_xl_pipe: Optional[Any] = None\n",
         "\n",
         "# --- 모델 로딩 ---\n",
         "def load_models():\n",
-        "    global base_pipe, controlnet_pipe, pipe_ip, ip_model, controlnet_preprocessor\n",
+        "    global ghibli_flux_pipe, anything_xl_pipe\n",
+        "    ghibli_flux_pipe = load_ghibli_flux_model(dtype)\n",
+        "    anything_xl_pipe = load_anything_xl_model(dtype)\n",
         "\n",
-        "    logger.info(f\"Loading models to CPU with dtype: {dtype}\")\n",
+        "# --- 모델 해체 ---\n",
+        "# lifespan에서 del 호출 필요\n",
         "\n",
-        "    # Base pipeline\n",
-        "    base_pipe = FluxPipeline.from_pretrained(BASE_MODEL_ID, torch_dtype=dtype).to(\"cpu\")\n",
-        "    base_pipe.enable_model_cpu_offload()\n",
-        "    base_pipe.enable_attention_slicing()\n",
-        "    base_pipe.enable_vae_slicing()\n",
-        "    # base_pipe.enable_xformers_memory_efficient_attention()\n",
+        "# ----------------------------------------------------------------\n",
         "\n",
-        "    '''\n",
-        "    2025.05.01 - t2i만 사용하기에 oom 방지 차원에서 모두 주석처리\n",
-        "    '''\n",
-        "    # # ControlNet pipeline\n",
-        "    # controlnet_model = FluxControlNetModel.from_pretrained(CONTROLNET_MODEL_ID, torch_dtype=dtype)\n",
-        "    # controlnet_pipe = FluxControlNetPipeline.from_pretrained(BASE_MODEL_ID, controlnet=controlnet_model, torch_dtype=dtype).to(\"cpu\")\n",
-        "    # controlnet_pipe.enable_model_cpu_offload()\n",
-        "    # controlnet_pipe.enable_attention_slicing()\n",
-        "    # controlnet_pipe.enable_vae_slicing()\n",
-        "    # # controlnet_pipe.enable_xformers_memory_efficient_attention()\n",
-        "\n",
-        "    # # IP-Adapter pipeline\n",
-        "    # transformer = FluxTransformer2DModel.from_pretrained(BASE_MODEL_ID, subfolder=\"transformer\", torch_dtype=dtype)\n",
-        "    # pipe_ip = FluxPipelineIP.from_pretrained(BASE_MODEL_ID, transformer=transformer, torch_dtype=dtype).to(\"cpu\")\n",
-        "    # pipe_ip.enable_model_cpu_offload()\n",
-        "    # pipe_ip.enable_attention_slicing()\n",
-        "    # pipe_ip.enable_vae_slicing()\n",
-        "    # # pipe_ip.enable_xformers_memory_efficient_attention()\n",
-        "\n",
-        "    # ip_model = IPAdapter(pipe_ip, IMAGE_ENCODER_PATH, IPADAPTER_PATH, device=\"cuda\", num_tokens=128)\n",
-        "\n",
-        "    # controlnet_preprocessor = CannyDetector()\n",
-        "    logger.info(\"✅ All models loaded and prepared on CPU.\")\n",
         "\n",
         "# --- 서버 생명주기 ---\n",
         "@asynccontextmanager\n",
@@ -272,7 +321,6 @@
         "    logger.info(\"App starting...\")\n",
         "    load_models()\n",
         "\n",
-        "    # ✅ Colab에서 설정한 환경변수로부터 ngrok URL 가져오기\n",
         "    public_url = os.environ.get(\"NGROK_STATIC_URL\", None)\n",
         "    app.state.ngrok_url = public_url\n",
         "    logger.info(f\"Ngrok (external) URL registered: {public_url}\")\n",
@@ -280,16 +328,16 @@
         "    yield\n",
         "\n",
         "    logger.info(\"App shutting down...\")\n",
-        "    del base_pipe, controlnet_pipe, pipe_ip, ip_model\n",
+        "    del ghibli_flux_pipe, anything_xl_pipe\n",
         "    gc.collect()\n",
         "    torch.cuda.empty_cache()\n",
-        "\n",
         "\n",
         "# --- FastAPI 앱 생성 ---\n",
         "app = FastAPI(lifespan=lifespan)\n",
         "\n",
         "# --- 요청 모델 ---\n",
         "class TextToImageRequest(BaseModel):\n",
+        "    model_name: str\n",
         "    prompt: str\n",
         "    negative_prompt: Optional[str] = \"\"\n",
         "    num_inference_steps: int = DEFAULT_STEPS\n",
@@ -300,7 +348,7 @@
         "@app.get(\"/\")\n",
         "async def read_root():\n",
         "    return {\n",
-        "        \"message\": \"Flux Unified API is running.\",\n",
+        "        \"message\": \"Image Model(text to image) API is running.\",\n",
         "        \"device\": device,\n",
         "        \"ngrok_url\": app.state.ngrok_url if hasattr(app.state, \"ngrok_url\") else None,\n",
         "    }\n",
@@ -308,15 +356,22 @@
         "# --- 텍스트 → 이미지 ---\n",
         "@app.post(\"/generate/text-to-image\", response_class=Response)\n",
         "async def generate_text_to_image(request: TextToImageRequest):\n",
-        "    if base_pipe is None:\n",
-        "        raise HTTPException(status_code=503, detail=\"Base pipeline not loaded.\")\n",
+        "    if request.model_name == \"ghibli-flux\":\n",
+        "        if ghibli_flux_pipe is None:\n",
+        "            raise HTTPException(status_code=503, detail=\"Ghibli-Flux pipeline not loaded.\")\n",
+        "        pipe = ghibli_flux_pipe\n",
+        "    elif request.model_name == \"anything-xl\":\n",
+        "        if anything_xl_pipe is None:\n",
+        "            raise HTTPException(status_code=503, detail=\"Anything-XL pipeline not loaded.\")\n",
+        "        pipe = anything_xl_pipe\n",
+        "    else:\n",
+        "        raise HTTPException(status_code=400, detail=f\"Invalid mode: {request.mode}\")\n",
         "\n",
-        "    base_pipe.to(\"cuda\")\n",
         "    generator = get_generator(request.seed)\n",
         "\n",
         "    try:\n",
         "        with torch.inference_mode():\n",
-        "            result = base_pipe(\n",
+        "            result = pipe(\n",
         "                prompt=request.prompt,\n",
         "                negative_prompt=request.negative_prompt,\n",
         "                width=IMAGE_WIDTH,\n",
@@ -328,79 +383,6 @@
         "            image_bytes = image_to_bytes(result.images[0])\n",
         "    finally:\n",
         "        del result\n",
-        "        base_pipe.to(\"cpu\")\n",
-        "        torch.cuda.empty_cache()\n",
-        "        gc.collect()\n",
-        "\n",
-        "    return Response(content=image_bytes, media_type=\"image/png\")\n",
-        "\n",
-        "# --- 이미지 → 이미지 (ControlNet) ---\n",
-        "@app.post(\"/generate/image-to-image\", response_class=Response)\n",
-        "async def generate_image_to_image(\n",
-        "    prompt: str = Form(...),\n",
-        "    negative_prompt: Optional[str] = Form(\"\"),\n",
-        "    controlnet_scale: float = Form(DEFAULT_CONTROLNET_SCALE),\n",
-        "    num_inference_steps: int = Form(DEFAULT_STEPS),\n",
-        "    guidance_scale: float = Form(DEFAULT_GUIDANCE_SCALE),\n",
-        "    seed: Optional[int] = Form(None),\n",
-        "    image: UploadFile = File(...)\n",
-        "):\n",
-        "    if controlnet_pipe is None:\n",
-        "        raise HTTPException(status_code=503, detail=\"ControlNet pipeline not ready.\")\n",
-        "\n",
-        "    control_image = prepare_control_image(image)\n",
-        "    controlnet_pipe.to(\"cuda\")\n",
-        "    generator = get_generator(seed)\n",
-        "\n",
-        "    try:\n",
-        "        with torch.inference_mode():\n",
-        "            result = controlnet_pipe(\n",
-        "                prompt=prompt,\n",
-        "                image=control_image,\n",
-        "                width=IMAGE_WIDTH,\n",
-        "                height=IMAGE_HEIGHT,\n",
-        "                num_inference_steps=num_inference_steps,\n",
-        "                guidance_scale=guidance_scale,\n",
-        "                controlnet_conditioning_scale=controlnet_scale,\n",
-        "                generator=generator,\n",
-        "            )\n",
-        "            image_bytes = image_to_bytes(result.images[0])\n",
-        "    finally:\n",
-        "        del result\n",
-        "        controlnet_pipe.to(\"cpu\")\n",
-        "        torch.cuda.empty_cache()\n",
-        "        gc.collect()\n",
-        "\n",
-        "    return Response(content=image_bytes, media_type=\"image/png\")\n",
-        "\n",
-        "# --- IP-Adapter 기반 참조 이미지 생성 ---\n",
-        "@app.post(\"/generate/ip-adapter-image\", response_class=Response)\n",
-        "async def generate_ip_adapter_image(\n",
-        "    prompt: str = Form(...),\n",
-        "    ipadapter_scale: float = Form(DEFAULT_IPADAPTER_SCALE),\n",
-        "    num_inference_steps: int = Form(DEFAULT_STEPS),\n",
-        "    seed: Optional[int] = Form(None),\n",
-        "    image: UploadFile = File(...)\n",
-        "):\n",
-        "    if ip_model is None:\n",
-        "        raise HTTPException(status_code=503, detail=\"IP-Adapter model not ready.\")\n",
-        "\n",
-        "    reference_image = await prepare_reference_image(image)\n",
-        "    pipe_ip.to(\"cuda\")\n",
-        "\n",
-        "    try:\n",
-        "        with torch.inference_mode():\n",
-        "            output_images = ip_model.generate(\n",
-        "                pil_image=reference_image,\n",
-        "                prompt=prompt,\n",
-        "                scale=ipadapter_scale,\n",
-        "                width=IMAGE_WIDTH,\n",
-        "                height=IMAGE_HEIGHT,\n",
-        "                seed=seed,\n",
-        "            )\n",
-        "            image_bytes = image_to_bytes(output_images[0])\n",
-        "    finally:\n",
-        "        pipe_ip.to(\"cpu\")\n",
         "        torch.cuda.empty_cache()\n",
         "        gc.collect()\n",
         "\n",
@@ -410,28 +392,30 @@
         "if __name__ == \"__main__\":\n",
         "    logger.info(\"Starting Uvicorn server...\")\n",
         "    uvicorn.run(\"main_server:app\", host=\"0.0.0.0\", port=PORT, reload=False)\n"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
       "metadata": {
+        "cellView": "form",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "cellView": "form",
-        "id": "XXvUlWb9HRcD",
-        "outputId": "dbbf07d1-7dbd-4120-ce58-ad6069363cda"
+        "id": "9hmI4LjHXoTF",
+        "outputId": "77e6b4c7-fd43-4e63-bdad-3e62f9798fce"
       },
-      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Writing main_server.py\n"
+            "✅ ngrok 프로세스 종료 완료\n",
+            "🧹 GPU 메모리 및 캐시 정리 완료\n",
+            "✅ FastAPI 서버 프로세스 종료 완료\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "# @title Fin.\n",
         "import subprocess\n",
@@ -468,30 +452,85 @@
         "print(\"✅ FastAPI 서버 프로세스 종료 완료\")\n",
         "\n",
         "!ps -ef | grep -E \"main_server.py\" | grep -v grep\n"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
       "metadata": {
+        "id": "oCqXd-e1uVX7",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "cellView": "form",
-        "id": "9hmI4LjHXoTF",
-        "outputId": "298d5aa9-7356-4b7a-e88f-6f318ea6f0cc"
+        "outputId": "ed44abf3-ffe9-4d05-d0bf-5868d129a0c6"
       },
-      "execution_count": 6,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "✅ ngrok 프로세스 종료 완료\n",
-            "🧹 GPU 메모리 및 캐시 정리 완료\n",
-            "✅ FastAPI 서버 프로세스 종료 완료\n"
+            "env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True\n",
+            "🛠 기존 ngrok / 서버 종료 시도...\n",
+            "✅ ngrok 종료 완료\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "INFO:pyngrok.ngrok:Opening tunnel named: http-8000-edf0a590-8e40-4bcc-a40c-4d4603db2c36\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:05+0000 lvl=info msg=\"no configuration paths supplied\"\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:05+0000 lvl=info msg=\"using configuration at default config path\" path=/root/.config/ngrok/ngrok.yml\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:05+0000 lvl=info msg=\"open config file\" path=/root/.config/ngrok/ngrok.yml err=nil\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:05+0000 lvl=info msg=\"starting web service\" obj=web addr=127.0.0.1:4040 allow_hosts=[]\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "🌐 ngrok 고정 도메인 연결 시도: clam-talented-promptly.ngrok-free.app...\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=\"client session established\" obj=tunnels.session\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=\"tunnel session started\" obj=tunnels.session\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=start pg=/api/tunnels id=09d7b73e5be89387\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=end pg=/api/tunnels id=09d7b73e5be89387 status=200 dur=300.023µs\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=start pg=/api/tunnels id=a32c1be786dbd981\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=end pg=/api/tunnels id=a32c1be786dbd981 status=200 dur=112.174µs\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=start pg=/api/tunnels id=e7cad0985e1cd2d8\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=\"started tunnel\" obj=tunnels name=http-8000-edf0a590-8e40-4bcc-a40c-4d4603db2c36 addr=http://localhost:8000 url=https://clam-talented-promptly.ngrok-free.app\n",
+            "INFO:pyngrok.process.ngrok:t=2025-05-27T08:03:06+0000 lvl=info msg=end pg=/api/tunnels id=e7cad0985e1cd2d8 status=201 dur=247.304805ms\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ ngrok 연결 완료: https://clam-talented-promptly.ngrok-free.app\n",
+            "🚀 FastAPI 서버 실행 중... 로그 파일: uvicorn_server.log\n",
+            "⏳ 모델 로딩 대기 중... ('Uvicorn running on' 감지)\n",
+            "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 \n",
+            "31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 \n",
+            "61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 \n",
+            "✅ 서버 준비 완료!\n",
+            "⌛ 안정화를 위해 10초 대기 중...\n",
+            "\n",
+            "🎯 서버 실행 완료! 외부 접속 URL:\n",
+            "🔗 https://clam-talented-promptly.ngrok-free.app\n",
+            "\n",
+            "📋 현재 실행 중인 프로세스:\n",
+            "root        3922    2408  0 08:03 ?        00:00:00 /root/.config/ngrok/ngrok start --none --log stdout\n",
+            "root        3951       1 99 08:03 ?        00:02:32 python3 main_server.py\n",
+            "\n",
+            "Total time : 398.92 seconds\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "# @title 🚀 ngrok 연결 및 FastAPI 서버 실행\n",
         "# 환경 변수 설정\n",
@@ -513,7 +552,7 @@
         "LOG_FILE = \"uvicorn_server.log\"\n",
         "STATIC_NGROK_DOMAIN = \"clam-talented-promptly.ngrok-free.app\"  # 사용자 고정 도메인\n",
         "MAX_WAIT_SECONDS = 300  # 최대 대기 시간\n",
-        "READY_KEYWORD = \"All models loaded\"\n",
+        "READY_KEYWORD = \"Uvicorn running on\"\n",
         "\n",
         "# --- ngrok 및 서버 종료 ---\n",
         "print(\"🛠 기존 ngrok / 서버 종료 시도...\")\n",
@@ -564,7 +603,7 @@
         "        try:\n",
         "            with open(LOG_FILE, 'r') as f:\n",
         "                if READY_KEYWORD in f.read():\n",
-        "                    print(\"\\n✅ 모델 로딩 감지 완료!\")\n",
+        "                    print(\"\\n✅ 서버 준비 완료!\")\n",
         "                    ready_detected = True\n",
         "                    break\n",
         "        except Exception as e:\n",
@@ -584,102 +623,28 @@
         "print(f\"🔗 {public_url}\")\n",
         "\n",
         "print(\"\\n📋 현재 실행 중인 프로세스:\")\n",
-        "!ps -ef | grep -E \"main_server.py|ngrok\" | grep -v grep\n"
-      ],
-      "metadata": {
-        "id": "oCqXd-e1uVX7",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "7be7e4f4-27cb-4dba-8f88-66b4198a8ec5"
-      },
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True\n",
-            "🛠 기존 ngrok / 서버 종료 시도...\n",
-            "✅ ngrok 종료 완료\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "INFO:pyngrok.ngrok:Opening tunnel named: http-8000-6a096fa8-1ceb-4002-bfca-a9a303c43147\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"no configuration paths supplied\"\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"using configuration at default config path\" path=/root/.config/ngrok/ngrok.yml\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"open config file\" path=/root/.config/ngrok/ngrok.yml err=nil\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"starting web service\" obj=web addr=127.0.0.1:4040 allow_hosts=[]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "🌐 ngrok 고정 도메인 연결 시도: clam-talented-promptly.ngrok-free.app...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"client session established\" obj=tunnels.session\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"tunnel session started\" obj=tunnels.session\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=start pg=/api/tunnels id=26d11516cb1d67aa\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=end pg=/api/tunnels id=26d11516cb1d67aa status=200 dur=254µs\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=start pg=/api/tunnels id=6ae3ef056f262b60\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=end pg=/api/tunnels id=6ae3ef056f262b60 status=200 dur=67.284µs\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=start pg=/api/tunnels id=faed313e61234917\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=\"started tunnel\" obj=tunnels name=http-8000-6a096fa8-1ceb-4002-bfca-a9a303c43147 addr=http://localhost:8000 url=https://clam-talented-promptly.ngrok-free.app\n",
-            "INFO:pyngrok.process.ngrok:t=2025-05-01T23:53:34+0000 lvl=info msg=end pg=/api/tunnels id=faed313e61234917 status=201 dur=31.073424ms\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "✅ ngrok 연결 완료: https://clam-talented-promptly.ngrok-free.app\n",
-            "🚀 FastAPI 서버 실행 중... 로그 파일: uvicorn_server.log\n",
-            "⏳ 모델 로딩 대기 중... ('All models loaded' 감지)\n",
-            "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 \n",
-            "31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 \n",
-            "61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 \n",
-            "91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 \n",
-            "✅ 모델 로딩 감지 완료!\n",
-            "⌛ 안정화를 위해 10초 대기 중...\n",
-            "\n",
-            "🎯 서버 실행 완료! 외부 접속 URL:\n",
-            "🔗 https://clam-talented-promptly.ngrok-free.app\n",
-            "\n",
-            "📋 현재 실행 중인 프로세스:\n",
-            "root        2300    1537  0 23:53 ?        00:00:00 /root/.config/ngrok/ngrok start --none --log=stdout\n",
-            "root        2322       1 90 23:53 ?        00:01:48 python3 main_server.py\n"
-          ]
-        }
+        "!ps -ef | grep -E \"main_server.py|ngrok\" | grep -v grep\n",
+        "\n",
+        "g_end = time.time()\n",
+        "print(f\"\\nTotal time : {(g_end - g_start):.2f} seconds\")\n"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!nvidia-smi"
-      ],
+      "execution_count": 10,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "qrax2DLnOrYR",
-        "outputId": "307a46aa-51c8-4dc0-b1bc-4cf8af650b39"
+        "outputId": "c311dd6b-89ee-4fb1-c8a8-25f247f24026"
       },
-      "execution_count": 10,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Fri May  2 00:01:14 2025       \n",
+            "Tue May 27 08:04:45 2025       \n",
             "+-----------------------------------------------------------------------------------------+\n",
             "| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |\n",
             "|-----------------------------------------+------------------------+----------------------+\n",
@@ -688,7 +653,7 @@
             "|                                         |                        |               MIG M. |\n",
             "|=========================================+========================+======================|\n",
             "|   0  NVIDIA A100-SXM4-40GB          Off |   00000000:00:04.0 Off |                    0 |\n",
-            "| N/A   34C    P0             55W /  400W |     541MiB /  40960MiB |      0%      Default |\n",
+            "| N/A   33C    P0             46W /  400W |       5MiB /  40960MiB |      0%      Default |\n",
             "|                                         |                        |             Disabled |\n",
             "+-----------------------------------------+------------------------+----------------------+\n",
             "                                                                                         \n",
@@ -697,13 +662,42 @@
             "|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |\n",
             "|        ID   ID                                                               Usage      |\n",
             "|=========================================================================================|\n",
+            "|  No running processes found                                                             |\n",
             "+-----------------------------------------------------------------------------------------+\n"
           ]
         }
+      ],
+      "source": [
+        "!nvidia-smi"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "QGXTSJyYllKv",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 197
+        },
+        "cellView": "form",
+        "outputId": "2af44e42-0c26-4239-93d9-d712c78e1694"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'\\n# 이 셀은 FastAPI 서버 코드를 main_server.py 파일로 저장합니다.\\n%%writefile main_server.py\\nimport os\\nimport io\\nimport logging\\nimport gc\\nfrom contextlib import asynccontextmanager\\nfrom typing import Optional, Any\\n\\nimport torch\\nimport uvicorn\\nfrom fastapi import FastAPI, HTTPException, UploadFile, File, Form\\nfrom fastapi.responses import Response\\nfrom pydantic import BaseModel\\nfrom PIL import Image\\nfrom pyngrok import ngrok\\n\\n# Diffusers - Flux + ControlNet\\nfrom diffusers import FluxPipeline, FluxControlNetModel, FluxControlNetPipeline\\nfrom controlnet_aux import CannyDetector\\n\\n# IP-Adapter\\nfrom pipeline_flux_ipa import FluxPipeline as FluxPipelineIP\\nfrom transformer_flux import FluxTransformer2DModel\\nfrom infer_flux_ipa_siglip import resize_img, IPAdapter\\n\\n# --- Configuration ---\\nBASE_MODEL_ID = \"black-forest-labs/FLUX.1-dev\"\\nCONTROLNET_MODEL_ID = \"Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0\"\\nIMAGE_ENCODER_PATH = \"google/siglip-so400m-patch14-384\"\\nIPADAPTER_PATH = \"./ip-adapter.bin\"\\n\\nDEFAULT_STEPS = 30\\nDEFAULT_GUIDANCE_SCALE = 3.5\\nDEFAULT_CONTROLNET_SCALE = 0.7\\nDEFAULT_IPADAPTER_SCALE = 0.7\\nIMAGE_WIDTH = 1024\\nIMAGE_HEIGHT = 1024\\nPORT = 8000\\n\\n# --- Global State ---\\nbase_pipe: Optional[FluxPipeline] = None\\ncontrolnet_pipe: Optional[FluxControlNetPipeline] = None\\ncontrolnet_preprocessor: Optional[Any] = None\\npipe_ip: Optional[FluxPipelineIP] = None\\nip_model: Optional[IPAdapter] = None\\ndevice: Optional[str] = None\\n\\nlogging.basicConfig(level=logging.INFO)\\nlogger = logging.getLogger(__name__)\\n\\n# --- Helper Functions ---\\ndef load_pil_image(image_bytes: bytes) -> Image.Image:\\n    return Image.open(io.BytesIO(image_bytes)).convert(\"RGB\")\\n\\ndef image_to_bytes(image: Image.Image) -> bytes:\\n    byte_arr = io.BytesIO()\\n    image.save(byte_arr, format=\\'PNG\\')\\n    byte_arr.seek(0)\\n    return byte_arr.getvalue()\\n\\ndef get_generator(seed: Optional[int] = None) -> torch.Generator:\\n    if seed is None:\\n        seed = torch.randint(0, 2**32 - 1, (1,)).item()\\n    logger.info(f\"Using seed: {seed}\")\\n    return torch.Generator(device=device).manual_seed(seed)\\n\\nasync def prepare_reference_image(uploaded_image: UploadFile) -> Image.Image:\\n    image = load_pil_image(await uploaded_image.read())\\n    return resize_img(image)\\n\\ndef prepare_control_image(uploaded_image: UploadFile) -> Image.Image:\\n    if controlnet_preprocessor is None:\\n        raise RuntimeError(\"ControlNet preprocessor not loaded.\")\\n    image = load_pil_image(uploaded_image.file.read())\\n    control_image = controlnet_preprocessor(image)\\n    return control_image\\n\\n# --- Model Loading ---\\ndef load_models():\\n    global base_pipe, controlnet_pipe, controlnet_preprocessor, pipe_ip, ip_model, device\\n\\n    device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\\n    logger.info(f\"Using device: {device}\")\\n    dtype = torch.bfloat16 if device == \"cuda\" and torch.cuda.is_bf16_supported() else torch.float16\\n\\n    colab_log_flag = \\'O\\'\\n    try:\\n        logger.info(\"Loading Flux base model...\")\\n        base_pipe = FluxPipeline.from_pretrained(BASE_MODEL_ID, torch_dtype=dtype)\\n        base_pipe.to(\"cpu\")\\n        base_pipe.enable_model_cpu_offload()\\n        base_pipe.enable_attention_slicing()\\n\\n        logger.info(\"Loading Flux ControlNet model...\")\\n        controlnet_model = FluxControlNetModel.from_pretrained(CONTROLNET_MODEL_ID, torch_dtype=dtype)\\n        controlnet_pipe = FluxControlNetPipeline.from_pretrained(BASE_MODEL_ID, controlnet=controlnet_model, torch_dtype=dtype)\\n        controlnet_pipe.to(\"cpu\")\\n        controlnet_pipe.enable_model_cpu_offload()\\n        controlnet_pipe.enable_attention_slicing()\\n\\n        logger.info(\"Loading Canny Preprocessor...\")\\n        controlnet_preprocessor = CannyDetector()\\n\\n        logger.info(\"Loading Flux IP-Adapter model...\")\\n        transformer = FluxTransformer2DModel.from_pretrained(BASE_MODEL_ID, subfolder=\"transformer\", torch_dtype=dtype)\\n        pipe_ip = FluxPipelineIP.from_pretrained(BASE_MODEL_ID, transformer=transformer, torch_dtype=dtype)\\n        ip_model = IPAdapter(\\n            pipe_ip,\\n            IMAGE_ENCODER_PATH,\\n            IPADAPTER_PATH,\\n            device=device,\\n            num_tokens=128\\n        )\\n        pipe_ip.to(\"cpu\")\\n        pipe_ip.enable_model_cpu_offload()\\n        pipe_ip.enable_attention_slicing()\\n\\n    except Exception as e:\\n        logger.exception(\"Fatal error during model loading\")\\n        colab_log_flag = \\'X\\'\\n        raise RuntimeError(f\"Failed to load models: {e}\")\\n\\n    logger.info(\"✅ All models loaded.\")\\n    print(colab_log_flag)\\n\\n# --- FastAPI Setup ---\\n@asynccontextmanager\\nasync def lifespan(app: FastAPI):\\n    logger.info(\"Application startup...\")\\n    load_models()\\n    ngrok_auth_token = os.environ.get(\"NGROK_AUTHTOKEN\")\\n    if ngrok_auth_token:\\n        public_url = ngrok.connect(PORT, \"http\")\\n        logger.info(f\"Ngrok tunnel active at: {public_url}\")\\n        app.state.ngrok_url = public_url\\n    else:\\n        app.state.ngrok_url = None\\n    yield\\n    logger.info(\"Application shutdown...\")\\n    ngrok.kill()\\n    global base_pipe, controlnet_pipe, pipe_ip\\n    del base_pipe, controlnet_pipe, pipe_ip\\n    if device == \"cuda\":\\n        torch.cuda.empty_cache()\\n\\napp = FastAPI(lifespan=lifespan, title=\"Flux Unified API\")\\n\\n# --- Pydantic Model ---\\nclass TextToImageRequest(BaseModel):\\n    prompt: str\\n    negative_prompt: Optional[str] = \"\"\\n    num_inference_steps: int = DEFAULT_STEPS\\n    guidance_scale: float = DEFAULT_GUIDANCE_SCALE\\n    seed: Optional[int] = None\\n\\n# --- API Endpoints ---\\n@app.get(\"/\")\\nasync def read_root():\\n    return {\\n        \"message\": \"Flux Unified API running.\",\\n        \"device\": device,\\n        \"ngrok_url\": app.state.ngrok_url if hasattr(app.state, \"ngrok_url\") else None\\n    }\\n\\n@app.post(\"/generate/text-to-image\", response_class=Response)\\nasync def generate_text_to_image(request: TextToImageRequest):\\n    if base_pipe is None:\\n        raise HTTPException(status_code=503, detail=\"Base pipeline not ready.\")\\n    base_pipe.to(\"cuda\")\\n    generator = get_generator(request.seed)\\n\\n    try:\\n        with torch.inference_mode():\\n            result = base_pipe(\\n                prompt=request.prompt,\\n                negative_prompt=request.negative_prompt,\\n                width=IMAGE_WIDTH,\\n                height=IMAGE_HEIGHT,\\n                num_inference_steps=request.num_inference_steps,\\n                guidance_scale=request.guidance_scale,\\n                generator=generator,\\n            )\\n        output_image = result.images[0]\\n        img_bytes = image_to_bytes(output_image)\\n        return Response(content=img_bytes, media_type=\"image/png\")\\n    finally:\\n        base_pipe.to(\"cpu\")\\n        torch.cuda.empty_cache()\\n        gc.collect()\\n\\n@app.post(\"/generate/image-to-image\", response_class=Response)\\nasync def generate_image_to_image(\\n    prompt: str = Form(...),\\n    negative_prompt: Optional[str] = Form(\"\"),\\n    controlnet_scale: float = Form(DEFAULT_CONTROLNET_SCALE),\\n    num_inference_steps: int = Form(DEFAULT_STEPS),\\n    guidance_scale: float = Form(DEFAULT_GUIDANCE_SCALE),\\n    seed: Optional[int] = Form(None),\\n    image: UploadFile = File(...)\\n):\\n    if controlnet_pipe is None:\\n        raise HTTPException(status_code=503, detail=\"ControlNet pipeline not ready.\")\\n\\n    controlnet_pipe.to(\"cuda\")\\n    control_image = prepare_control_image(image)\\n    generator = get_generator(seed)\\n\\n    try:\\n        with torch.inference_mode():\\n            result = controlnet_pipe(\\n                prompt=prompt,\\n                image=control_image,\\n                width=IMAGE_WIDTH,\\n                height=IMAGE_HEIGHT,\\n                num_inference_steps=num_inference_steps,\\n                guidance_scale=guidance_scale,\\n                controlnet_conditioning_scale=controlnet_scale,\\n                generator=generator,\\n            )\\n        output_image = result.images[0]\\n        img_bytes = image_to_bytes(output_image)\\n        return Response(content=img_bytes, media_type=\"image/png\")\\n    finally:\\n        controlnet_pipe.to(\"cpu\")\\n        torch.cuda.empty_cache()\\n        gc.collect()\\n\\n@app.post(\"/generate/ip-adapter-image\", response_class=Response)\\nasync def generate_ip_adapter_image(\\n    prompt: str = Form(...),\\n    ipadapter_scale: float = Form(DEFAULT_IPADAPTER_SCALE),\\n    num_inference_steps: int = Form(DEFAULT_STEPS),\\n    seed: Optional[int] = Form(None),\\n    image: UploadFile = File(...)\\n):\\n    if ip_model is None:\\n        raise HTTPException(status_code=503, detail=\"IP-Adapter not ready.\")\\n\\n    pipe_ip.to(\"cuda\")\\n    reference_image = await prepare_reference_image(image)\\n\\n    try:\\n        with torch.inference_mode():\\n            output_images = ip_model.generate(\\n                pil_image=reference_image,\\n                prompt=prompt,\\n                scale=ipadapter_scale,\\n                width=IMAGE_WIDTH,\\n                height=IMAGE_HEIGHT,\\n                seed=seed,\\n            )\\n        output_image = output_images[0]\\n        img_bytes = image_to_bytes(output_image)\\n        return Response(content=img_bytes, media_type=\"image/png\")\\n    finally:\\n        pipe_ip.to(\"cpu\")\\n        torch.cuda.empty_cache()\\n        gc.collect()\\n\\n# --- Main ---\\nif __name__ == \"__main__\":\\n    logger.info(\"Starting Uvicorn server...\")\\n    uvicorn.run(\"main_server:app\", host=\"0.0.0.0\", port=PORT, reload=False)\\n'"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
+      ],
       "source": [
         "# @title [구버전 - to('cuda') 사용 중] FastAPI 애플리케이션 코드 작성 (main_server.py 파일 생성)\n",
         "'''\n",
@@ -972,31 +966,24 @@
         "    logger.info(\"Starting Uvicorn server...\")\n",
         "    uvicorn.run(\"main_server:app\", host=\"0.0.0.0\", port=PORT, reload=False)\n",
         "'''"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 197
-        },
-        "id": "QGXTSJyYllKv",
-        "outputId": "6f20acd9-9490-4079-fe85-562ecff68553"
-      },
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "'\\n# 이 셀은 FastAPI 서버 코드를 main_server.py 파일로 저장합니다.\\n%%writefile main_server.py\\nimport os\\nimport io\\nimport logging\\nimport gc\\nfrom contextlib import asynccontextmanager\\nfrom typing import Optional, Any\\n\\nimport torch\\nimport uvicorn\\nfrom fastapi import FastAPI, HTTPException, UploadFile, File, Form\\nfrom fastapi.responses import Response\\nfrom pydantic import BaseModel\\nfrom PIL import Image\\nfrom pyngrok import ngrok\\n\\n# Diffusers - Flux + ControlNet\\nfrom diffusers import FluxPipeline, FluxControlNetModel, FluxControlNetPipeline\\nfrom controlnet_aux import CannyDetector\\n\\n# IP-Adapter\\nfrom pipeline_flux_ipa import FluxPipeline as FluxPipelineIP\\nfrom transformer_flux import FluxTransformer2DModel\\nfrom infer_flux_ipa_siglip import resize_img, IPAdapter\\n\\n# --- Configuration ---\\nBASE_MODEL_ID = \"black-forest-labs/FLUX.1-dev\"\\nCONTROLNET_MODEL_ID = \"Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0\"\\nIMAGE_ENCODER_PATH = \"google/siglip-so400m-patch14-384\"\\nIPADAPTER_PATH = \"./ip-adapter.bin\"\\n\\nDEFAULT_STEPS = 30\\nDEFAULT_GUIDANCE_SCALE = 3.5\\nDEFAULT_CONTROLNET_SCALE = 0.7\\nDEFAULT_IPADAPTER_SCALE = 0.7\\nIMAGE_WIDTH = 1024\\nIMAGE_HEIGHT = 1024\\nPORT = 8000\\n\\n# --- Global State ---\\nbase_pipe: Optional[FluxPipeline] = None\\ncontrolnet_pipe: Optional[FluxControlNetPipeline] = None\\ncontrolnet_preprocessor: Optional[Any] = None\\npipe_ip: Optional[FluxPipelineIP] = None\\nip_model: Optional[IPAdapter] = None\\ndevice: Optional[str] = None\\n\\nlogging.basicConfig(level=logging.INFO)\\nlogger = logging.getLogger(__name__)\\n\\n# --- Helper Functions ---\\ndef load_pil_image(image_bytes: bytes) -> Image.Image:\\n    return Image.open(io.BytesIO(image_bytes)).convert(\"RGB\")\\n\\ndef image_to_bytes(image: Image.Image) -> bytes:\\n    byte_arr = io.BytesIO()\\n    image.save(byte_arr, format=\\'PNG\\')\\n    byte_arr.seek(0)\\n    return byte_arr.getvalue()\\n\\ndef get_generator(seed: Optional[int] = None) -> torch.Generator:\\n    if seed is None:\\n        seed = torch.randint(0, 2**32 - 1, (1,)).item()\\n    logger.info(f\"Using seed: {seed}\")\\n    return torch.Generator(device=device).manual_seed(seed)\\n\\nasync def prepare_reference_image(uploaded_image: UploadFile) -> Image.Image:\\n    image = load_pil_image(await uploaded_image.read())\\n    return resize_img(image)\\n\\ndef prepare_control_image(uploaded_image: UploadFile) -> Image.Image:\\n    if controlnet_preprocessor is None:\\n        raise RuntimeError(\"ControlNet preprocessor not loaded.\")\\n    image = load_pil_image(uploaded_image.file.read())\\n    control_image = controlnet_preprocessor(image)\\n    return control_image\\n\\n# --- Model Loading ---\\ndef load_models():\\n    global base_pipe, controlnet_pipe, controlnet_preprocessor, pipe_ip, ip_model, device\\n\\n    device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\\n    logger.info(f\"Using device: {device}\")\\n    dtype = torch.bfloat16 if device == \"cuda\" and torch.cuda.is_bf16_supported() else torch.float16\\n\\n    colab_log_flag = \\'O\\'\\n    try:\\n        logger.info(\"Loading Flux base model...\")\\n        base_pipe = FluxPipeline.from_pretrained(BASE_MODEL_ID, torch_dtype=dtype)\\n        base_pipe.to(\"cpu\")\\n        base_pipe.enable_model_cpu_offload()\\n        base_pipe.enable_attention_slicing()\\n\\n        logger.info(\"Loading Flux ControlNet model...\")\\n        controlnet_model = FluxControlNetModel.from_pretrained(CONTROLNET_MODEL_ID, torch_dtype=dtype)\\n        controlnet_pipe = FluxControlNetPipeline.from_pretrained(BASE_MODEL_ID, controlnet=controlnet_model, torch_dtype=dtype)\\n        controlnet_pipe.to(\"cpu\")\\n        controlnet_pipe.enable_model_cpu_offload()\\n        controlnet_pipe.enable_attention_slicing()\\n\\n        logger.info(\"Loading Canny Preprocessor...\")\\n        controlnet_preprocessor = CannyDetector()\\n\\n        logger.info(\"Loading Flux IP-Adapter model...\")\\n        transformer = FluxTransformer2DModel.from_pretrained(BASE_MODEL_ID, subfolder=\"transformer\", torch_dtype=dtype)\\n        pipe_ip = FluxPipelineIP.from_pretrained(BASE_MODEL_ID, transformer=transformer, torch_dtype=dtype)\\n        ip_model = IPAdapter(\\n            pipe_ip,\\n            IMAGE_ENCODER_PATH,\\n            IPADAPTER_PATH,\\n            device=device,\\n            num_tokens=128\\n        )\\n        pipe_ip.to(\"cpu\")\\n        pipe_ip.enable_model_cpu_offload()\\n        pipe_ip.enable_attention_slicing()\\n\\n    except Exception as e:\\n        logger.exception(\"Fatal error during model loading\")\\n        colab_log_flag = \\'X\\'\\n        raise RuntimeError(f\"Failed to load models: {e}\")\\n\\n    logger.info(\"✅ All models loaded.\")\\n    print(colab_log_flag)\\n\\n# --- FastAPI Setup ---\\n@asynccontextmanager\\nasync def lifespan(app: FastAPI):\\n    logger.info(\"Application startup...\")\\n    load_models()\\n    ngrok_auth_token = os.environ.get(\"NGROK_AUTHTOKEN\")\\n    if ngrok_auth_token:\\n        public_url = ngrok.connect(PORT, \"http\")\\n        logger.info(f\"Ngrok tunnel active at: {public_url}\")\\n        app.state.ngrok_url = public_url\\n    else:\\n        app.state.ngrok_url = None\\n    yield\\n    logger.info(\"Application shutdown...\")\\n    ngrok.kill()\\n    global base_pipe, controlnet_pipe, pipe_ip\\n    del base_pipe, controlnet_pipe, pipe_ip\\n    if device == \"cuda\":\\n        torch.cuda.empty_cache()\\n\\napp = FastAPI(lifespan=lifespan, title=\"Flux Unified API\")\\n\\n# --- Pydantic Model ---\\nclass TextToImageRequest(BaseModel):\\n    prompt: str\\n    negative_prompt: Optional[str] = \"\"\\n    num_inference_steps: int = DEFAULT_STEPS\\n    guidance_scale: float = DEFAULT_GUIDANCE_SCALE\\n    seed: Optional[int] = None\\n\\n# --- API Endpoints ---\\n@app.get(\"/\")\\nasync def read_root():\\n    return {\\n        \"message\": \"Flux Unified API running.\",\\n        \"device\": device,\\n        \"ngrok_url\": app.state.ngrok_url if hasattr(app.state, \"ngrok_url\") else None\\n    }\\n\\n@app.post(\"/generate/text-to-image\", response_class=Response)\\nasync def generate_text_to_image(request: TextToImageRequest):\\n    if base_pipe is None:\\n        raise HTTPException(status_code=503, detail=\"Base pipeline not ready.\")\\n    base_pipe.to(\"cuda\")\\n    generator = get_generator(request.seed)\\n\\n    try:\\n        with torch.inference_mode():\\n            result = base_pipe(\\n                prompt=request.prompt,\\n                negative_prompt=request.negative_prompt,\\n                width=IMAGE_WIDTH,\\n                height=IMAGE_HEIGHT,\\n                num_inference_steps=request.num_inference_steps,\\n                guidance_scale=request.guidance_scale,\\n                generator=generator,\\n            )\\n        output_image = result.images[0]\\n        img_bytes = image_to_bytes(output_image)\\n        return Response(content=img_bytes, media_type=\"image/png\")\\n    finally:\\n        base_pipe.to(\"cpu\")\\n        torch.cuda.empty_cache()\\n        gc.collect()\\n\\n@app.post(\"/generate/image-to-image\", response_class=Response)\\nasync def generate_image_to_image(\\n    prompt: str = Form(...),\\n    negative_prompt: Optional[str] = Form(\"\"),\\n    controlnet_scale: float = Form(DEFAULT_CONTROLNET_SCALE),\\n    num_inference_steps: int = Form(DEFAULT_STEPS),\\n    guidance_scale: float = Form(DEFAULT_GUIDANCE_SCALE),\\n    seed: Optional[int] = Form(None),\\n    image: UploadFile = File(...)\\n):\\n    if controlnet_pipe is None:\\n        raise HTTPException(status_code=503, detail=\"ControlNet pipeline not ready.\")\\n\\n    controlnet_pipe.to(\"cuda\")\\n    control_image = prepare_control_image(image)\\n    generator = get_generator(seed)\\n\\n    try:\\n        with torch.inference_mode():\\n            result = controlnet_pipe(\\n                prompt=prompt,\\n                image=control_image,\\n                width=IMAGE_WIDTH,\\n                height=IMAGE_HEIGHT,\\n                num_inference_steps=num_inference_steps,\\n                guidance_scale=guidance_scale,\\n                controlnet_conditioning_scale=controlnet_scale,\\n                generator=generator,\\n            )\\n        output_image = result.images[0]\\n        img_bytes = image_to_bytes(output_image)\\n        return Response(content=img_bytes, media_type=\"image/png\")\\n    finally:\\n        controlnet_pipe.to(\"cpu\")\\n        torch.cuda.empty_cache()\\n        gc.collect()\\n\\n@app.post(\"/generate/ip-adapter-image\", response_class=Response)\\nasync def generate_ip_adapter_image(\\n    prompt: str = Form(...),\\n    ipadapter_scale: float = Form(DEFAULT_IPADAPTER_SCALE),\\n    num_inference_steps: int = Form(DEFAULT_STEPS),\\n    seed: Optional[int] = Form(None),\\n    image: UploadFile = File(...)\\n):\\n    if ip_model is None:\\n        raise HTTPException(status_code=503, detail=\"IP-Adapter not ready.\")\\n\\n    pipe_ip.to(\"cuda\")\\n    reference_image = await prepare_reference_image(image)\\n\\n    try:\\n        with torch.inference_mode():\\n            output_images = ip_model.generate(\\n                pil_image=reference_image,\\n                prompt=prompt,\\n                scale=ipadapter_scale,\\n                width=IMAGE_WIDTH,\\n                height=IMAGE_HEIGHT,\\n                seed=seed,\\n            )\\n        output_image = output_images[0]\\n        img_bytes = image_to_bytes(output_image)\\n        return Response(content=img_bytes, media_type=\"image/png\")\\n    finally:\\n        pipe_ip.to(\"cpu\")\\n        torch.cuda.empty_cache()\\n        gc.collect()\\n\\n# --- Main ---\\nif __name__ == \"__main__\":\\n    logger.info(\"Starting Uvicorn server...\")\\n    uvicorn.run(\"main_server:app\", host=\"0.0.0.0\", port=PORT, reload=False)\\n'"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            }
-          },
-          "metadata": {},
-          "execution_count": 9
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "A100",
+      "machine_shape": "hm",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Qwen3에 맞춰서 nodes_v2 제작

[구현 내용]
- n01 ~ n09까지 qwen3에 맞춰서 수정 (n10은 실제 업로드라 추후 확인 필요)

- writer_id와 mode를 매핑하여 선택 <state_v2에 전역변수 세팅 + N01에서 지정 중>
  - "1" : ghibli-flux
  - "2" : anything-xl
  - 이외 : ghibli-flux (DEFAULT_IMAGE_MODE)

[호출]
호출은 writer id로 매핑되기 때문에 그대로 진행해도 됩니다 (v1 postman과 동일)
대신에 n10은 없어서 실제로 s3에 올라가지는 않습니다!


[남은 부분]
- 전체적으로 max_token을 늘려서 멈추진 않는데, 방어로직은 부족합니다 (retry 등 불안정)

- workflow가 main_workflow 1개라 Handler와 붙일 때 추가로 만들어서 사용해야 합니다.

- Anything XL이 아직 이미지 서빙 colab (image_model_tunneling.ipynb)에 들어가지 않아서 추가해야합니다.

- 추가로 이미지 생성에서 굉장히 느려서 추후 xformers 적용 생각 중입니다.
  - 생성 속도는 아래와 같습니다 (1장 기준)
  - Flux 1 Dev 기반 : 평균 44 ~ 45초
  - Stable Diffusion XL 기반 : 평균 18 ~ 19초