### PR TITLE
ci : 리뷰어 할당 파이프라인 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @100-hours-a-week/NewSum_AI

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -1,0 +1,42 @@
+name: Set reviewers based on branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  set-reviewers:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # PR에 리뷰어를 추가할 수 있는 권한을 부여
+
+    steps:
+      # feature to dev로 PR 올라왔을 때
+      - name: feature에서 dev로 PR 올라올 때 AI팀으로 리뷰어 설정 
+        if: github.base_ref == 'dev' && github.head_ref != 'main'
+        run: |
+          # GitHub 조직에 속한 팀 목록을 가져오기(팀 슬러그 디버깅용)
+          teams=$(curl -s -H "Authorization: token ${{ secrets.REVIEW_TOKEN }}" \
+          https://api.github.com/orgs/100-hours-a-week/teams?per_page=100 | jq -r '.[].slug')
+          
+          echo "Teams: $teams"  # 팀 목록 출력
+
+          # AI 팀을 리뷰어로 설정
+          curl -s -X POST -H "Authorization: token ${{ secrets.REVIEW_TOKEN }}" \
+          -d '{"team_reviewers": ["newsum_ai"]}' \
+          https://api.github.com/repos/100-hours-a-week/17-newsum-ai/pulls/${{ github.event.pull_request.number }}/requested_reviewers
+
+      # dev to main으로 PR 올라왔을 때
+      - name: dev에서 main으로 PR 올라올 때 관리자 팀으로 리뷰어 설정
+        if: github.base_ref == 'main' && github.head_ref == 'dev'
+        run: |
+          # GitHub 조직에 속한 팀 목록을 가져오기(팀 슬러그 디버깅용)
+          teams=$(curl -s -H "Authorization: token ${{ secrets.REVIEW_TOKEN }}" \
+          https://api.github.com/orgs/100-hours-a-week/teams?per_page=100 | jq -r '.[].slug')
+          
+          echo "Teams: $teams"  # 팀 목록 출력
+          
+          # 관리자 팀을 리뷰어로 설정
+          curl -s -X POST -H "Authorization: token ${{ secrets.REVIEW_TOKEN }}" \
+          -d '{"team_reviewers": ["newsum_admin"]}' \
+          https://api.github.com/repos/100-hours-a-week/17-newsum-ai/pulls/${{ github.event.pull_request.number }}/requested_reviewers


### PR DESCRIPTION
dev-> main 브랜치로 갈때 CODEOWNERS 파일의 충돌을 해결하기 위해
yml 파이프라인으로 리뷰어 할당하는 구조로 수정하였습니다.